### PR TITLE
DD-42721 - Search index updates and data migration tool

### DIFF
--- a/ai-document-migration-tool/README.md
+++ b/ai-document-migration-tool/README.md
@@ -1,0 +1,170 @@
+# ai-document-migration-tool
+
+A one-off, resumable **index-to-index migration tool** for rebuilding the Azure AI Search index behind
+the RAG service with a corrected (v2) schema, copying all existing data across with **no re-embedding**.
+
+This module is **not deployed** — it is an operational utility run by hand when the search index schema
+needs to change.
+
+---
+
+## What it's for
+
+Azure AI Search field attributes such as `searchable`, `filterable`, `sortable`, `facetable`, `stored`
+and `type` are **immutable once an index contains data** — you cannot `ALTER` them in place — and the
+service has **no native index copy/backup** feature. The only supported way to change those attributes on
+a populated index is to **stand up a new index with the corrected schema and re-populate it**.
+
+This tool does exactly that, end to end:
+
+1. **Creates** the target index (`ai-rag-service-index-v2`) from the v2 schema
+   (`ai-document-shared-artefacts/src/main/resources/vector-db-index-schema-v2.json`).
+2. **Copies** every document from the source index to the target — vectors included, so there is **no
+   re-embedding** (all fields are `retrievable`, so the stored vectors are read back and re-uploaded as-is).
+3. **Verifies** the source and target document counts match.
+4. **Prints the alias cutover command** for a zero-downtime switch (see [How to run](#how-to-run)).
+
+---
+
+## Background & rationale
+
+The live index (`ai-rag-service-index`) was created with attribute flags that don't match how the service
+actually queries it — e.g. identifier/URL fields were `searchable` (so a free-text query could match on a
+filename or GUID and pollute relevance), and every field was `sortable`/`facetable` despite nothing ever
+sorting or faceting. Correcting these requires a schema change, which on a populated index means a rebuild.
+
+Because the rebuild has to move a large volume of high-dimensional vectors (3072-float embeddings) over the
+network, a naive sequential copy is slow. The tool therefore evolved to be **fast, resilient, and safe**:
+
+- **Keyset pagination** on the key (`orderby id asc` + `id gt '<cursor>'`) instead of `$skip`, which Azure
+  caps at 100,000 documents.
+- **Parallel sharded reads** — with `workers > 1` the UUID key space is split into 16 shards by leading hex
+  character and read concurrently, because the copy is dominated by per-page network round-trips while the
+  client sits idle.
+- A shared, thread-safe **buffered sender** that auto-batches, splits over-16 MB batches, and retries
+  throttling (429/503) — transient errors (e.g. `Connection reset` over a VPN) do **not** abort the run.
+- A **no-progress watchdog** so a genuinely hung request (e.g. a half-open socket) can never wedge the run
+  indefinitely — it aborts with a clear, re-runnable message instead.
+- A **`maxRecords` cap** to copy a small sample for validation before committing to a full run.
+
+> Throughput note: the copy is network-bound. Over a healthy/in-region path a full copy of ~340k documents
+> runs in the ~15-minute ballpark; over a degraded VPN/public-internet path it is slower and more prone to
+> connection resets. Running the tool **in the same Azure region** as the search service is the single
+> biggest lever for speed and stability.
+
+---
+
+## What has changed (v1 → v2 schema)
+
+The migration's purpose is to apply the v2 schema. **Document data is copied verbatim — only the index
+field _attributes_ change.** The changes are "hygiene" (removing unused/ harmful flags) plus making
+`documentId` directly filterable. See the [field table](#fields-migrated) below for the per-field detail.
+
+Summary of the v2 changes:
+
+- **Only `chunk` stays `searchable`** — identifier/URL/metadata fields are no longer lexically searched, so
+  keyword queries can't match on a filename, URL or GUID.
+- **`sortable` / `facetable` removed everywhere** they were unused (`id` keeps `sortable` because the
+  migration's keyset pagination orders by it).
+- **`documentId` is now `filterable`** (forward-looking enablement; the application filter code is unchanged).
+- **`synonymMaps` removed** from non-searchable fields.
+- **`chunkVector`, `retrievable`, `stored`, `dimensions`, vector/semantic/similarity config are unchanged.**
+
+The tool also encodes several operational decisions:
+
+- **Alias-based cutover.** The pinned `azure-search-documents` Java SDK has **no index-alias API**, so the
+  tool prints an `az rest` command (the data-plane REST API does support aliases) rather than calling the SDK.
+- **`SearchIndex` is immutable** (no `setName`), so the tool rewrites the schema JSON's `name` to the target
+  before parsing — every other property is preserved verbatim from the schema file.
+- **Sample runs are quarantined.** A `maxRecords`-capped run skips the full-count verification and does
+  **not** emit the cutover command, and logs that the target is a SAMPLE not to be promoted.
+
+---
+
+## How to run
+
+### Prerequisites
+
+- Authenticated via `DefaultAzureCredential` — locally this means `az login` (the tool logs which credential
+  it used). The principal needs **Search Service Contributor** (create index / read counts) and **Search
+  Index Data Contributor** (read source docs, write target docs).
+- HTTP/retry behaviour is configurable via the usual `AZURE_CLIENT_*` / `HTTP_CLIENT_*` env vars (defaults
+  are sensible; the Netty response timeout defaults to 180s).
+
+### Command
+
+```bash
+mvn -pl ai-document-migration-tool exec:java \
+  -Dexec.args="<endpoint> <sourceIndex> <targetIndex> <aliasName> <schemaResourcePath> [workers] [maxRecords] [startAfterId]"
+```
+
+```bash
+# Full copy, 8 concurrent shards
+mvn -pl ai-document-migration-tool exec:java \
+  -Dexec.args="https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 8"
+
+# Sample copy of the first 20,000 records (for validation) — no verification, no cutover command
+mvn -pl ai-document-migration-tool exec:java \
+  -Dexec.args="https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 8 20000"
+```
+
+### Arguments
+
+| # | Argument | Required | Default | Description |
+|---|----------|----------|---------|-------------|
+| 1 | `endpoint` | yes | — | Search service endpoint, e.g. `https://my-svc.search.windows.net` |
+| 2 | `sourceIndex` | yes | — | Existing index to copy **from** (e.g. `ai-rag-service-index`) |
+| 3 | `targetIndex` | yes | — | New index to create and copy **to** (e.g. `ai-rag-service-index-v2`) |
+| 4 | `aliasName` | yes | — | Alias name used in the printed cutover command (e.g. `ai-rag-service-index-alias`) |
+| 5 | `schemaResourcePath` | yes | — | Classpath path to the v2 schema (`/vector-db-index-schema-v2.json`) |
+| 6 | `workers` | no | `8` | Concurrent shard readers; effective parallelism is `min(workers, 16)` |
+| 7 | `maxRecords` | no | `0` (all) | Global cap on documents copied — a positive value makes it a **sample** run |
+| 8 | `startAfterId` | no | — | Resume cursor (single-worker runs only; ignored when `workers > 1`) |
+
+### Cutover
+
+A successful **full** run prints a ready-to-run `az rest` `PUT` that points the alias at the new index.
+After running it (allow ~10s to propagate and validating), set `AZURE_SEARCH_SERVICE_INDEX_NAME` to the
+**alias** in each environment's function settings. Future rebuilds become "build vN+1, repoint the alias"
+with no application change. Re-runs are safe — uploads are idempotent upserts keyed by `id`.
+
+---
+
+## Fields migrated
+
+Every field is **copied as-is** (values unchanged); the table shows the **attribute changes** applied by the
+v2 schema. `retrievable` and `stored` remain `true` on all fields (required so the copy can read every field,
+including the vector, back out). ✅ = enabled in v2, ❌ = disabled in v2; **bold** marks a change from v1.
+
+| Field | Type | searchable | filterable | sortable | facetable | What changed & why |
+|-------|------|:----------:|:----------:|:--------:|:---------:|--------------------|
+| `id` (key) | `Edm.String` | ❌ | ✅ | ✅ | **❌** | Dropped unused `facetable`. Kept `filterable`+`sortable` — the migration keyset-paginates on `id`. |
+| `chunk` | `Edm.String` | ✅ | **❌** | **❌** | **❌** | The only lexically-searched field. Dropped unused filter/sort/facet on this large text body. |
+| `chunkVector` | `Collection(Edm.Single)` (3072) | ✅ | ❌ | ❌ | ❌ | **Unchanged.** Vector field; `retrievable`/`stored` true so it copies without re-embedding. |
+| `documentFileName` | `Edm.String` | **❌** | ❌ | **❌** | **❌** | No longer lexically searched (identifier, not prose); dropped unused sort/facet. |
+| `documentId` | `Edm.String` | **❌** | **✅** | **❌** | **❌** | Now directly `filterable` (enablement); no longer `searchable`; dropped unused sort/facet. |
+| `pageNumber` | `Edm.Int32` | ❌ | **❌** | **❌** | **❌** | Retrieved only; dropped unused filter/sort/facet. |
+| `chunkIndex` | `Edm.Int32` | ❌ | **❌** | **❌** | **❌** | Retrieved only; dropped unused filter/sort/facet. |
+| `documentFileUrl` | `Edm.String` | **❌** | **❌** | **❌** | **❌** | Citation field, retrieved only; dropped searchable/filter/sort/facet. |
+| `customMetadata/key` | `Edm.String` (complex) | **❌** | ✅ | ❌ | **❌** | Kept `filterable` (drives the `/any(...)` metadata filters); dropped searchable/facetable. |
+| `customMetadata/value` | `Edm.String` (complex) | **❌** | ✅ | ❌ | **❌** | Kept `filterable` (drives the `/any(...)` metadata filters); dropped searchable/facetable. |
+
+> `synonymMaps: []` was also removed from every field except `chunk` (it only applies to searchable string
+> fields). Vector search (HNSW), semantic, and similarity (BM25) configuration are carried over unchanged.
+
+---
+
+## Design / code layout
+
+| Class | Responsibility |
+|-------|----------------|
+| `IndexMigrationTool` | Entry point (`main`): parses args and wires the pieces together |
+| `IndexCopier` | The parallel copy engine: keyset pagination, the record cap, the stall watchdog, ETA |
+| `Shard` | A key-space slice: partitioning (`plan`) and OData range/keyset filter construction |
+| `SearchIndexAdmin` | Client/sender construction, target-index creation, count verification, cutover command |
+
+### Build & test
+
+```bash
+mvn -pl ai-document-migration-tool -am clean test
+```

--- a/ai-document-migration-tool/README.md
+++ b/ai-document-migration-tool/README.md
@@ -1,83 +1,59 @@
 # ai-document-migration-tool
 
 A one-off, resumable **index-to-index migration tool** for rebuilding the Azure AI Search index behind
-the RAG service with a corrected (v2) schema, copying all existing data across with **no re-embedding**.
+the RAG service with a corrected schema, copying all existing data across with **no re-embedding**.
 
 This module is **not deployed** — it is an operational utility run by hand when the search index schema
 needs to change.
 
+> The specific schema changes this migration applies (and why) are documented separately in
+> **[SCHEMA_CHANGES.md](SCHEMA_CHANGES.md)**. This README focuses on how the tool works and how to run it.
+
 ---
 
-## What it's for
+## What it does
 
-Azure AI Search field attributes such as `searchable`, `filterable`, `sortable`, `facetable`, `stored`
-and `type` are **immutable once an index contains data** — you cannot `ALTER` them in place — and the
-service has **no native index copy/backup** feature. The only supported way to change those attributes on
-a populated index is to **stand up a new index with the corrected schema and re-populate it**.
+Azure AI Search field attributes (`searchable`, `filterable`, `sortable`, `facetable`, `stored`, `type`) are
+**immutable once an index contains data**, and the service has **no native index copy/backup**. The only
+supported way to change them is to stand up a new index with the corrected schema and re-populate it. This
+tool does that, end to end:
 
-This tool does exactly that, end to end:
-
-1. **Creates** the target index (`ai-rag-service-index-v2`) from the v2 schema
+1. **Creates** the target index from the v2 schema
    (`ai-document-shared-artefacts/src/main/resources/vector-db-index-schema-v2.json`).
 2. **Copies** every document from the source index to the target — vectors included, so there is **no
    re-embedding** (all fields are `retrievable`, so the stored vectors are read back and re-uploaded as-is).
-3. **Verifies** the source and target document counts match.
-4. **Prints the alias cutover command** for a zero-downtime switch (see [How to run](#how-to-run)).
+3. **Verifies** the source and target document counts (see the [verification caveat](#known-limitations--gotchas)).
+4. **Prints the alias cutover command** for a zero-downtime switch (see [Cutover](#cutover)).
 
 ---
 
-## Background & rationale
+## How it works
 
-The live index (`ai-rag-service-index`) was created with attribute flags that don't match how the service
-actually queries it — e.g. identifier/URL fields were `searchable` (so a free-text query could match on a
-filename or GUID and pollute relevance), and every field was `sortable`/`facetable` despite nothing ever
-sorting or faceting. Correcting these requires a schema change, which on a populated index means a rebuild.
+The copy is **network-bound** — most wall-clock is per-page round-trips to the service while the client sits
+idle — so the engine is built around concurrency, resilience, and bounded resource use:
 
-Because the rebuild has to move a large volume of high-dimensional vectors (3072-float embeddings) over the
-network, a naive sequential copy is slow. The tool therefore evolved to be **fast, resilient, and safe**:
+- **Keyset pagination** on the key (`orderby id asc` + `id gt '<cursor>'`) rather than `$skip` (which Azure
+  caps at 100,000 documents). Each page advances a cursor, so it scales to any index size.
+- **Sharded parallel reads** — with `workers > 1` the UUID key space is split into **16 shards** by the
+  leading hex character of `id`, run concurrently on a fixed thread pool (`min(workers, 16)` at a time). Each
+  shard runs its own independent keyset paginator.
+- **Pluggable upload path** (`DocumentUploader`) — async (buffered sender) for throughput, or synchronous
+  per-page for bounded memory; selected at runtime. See [Upload modes & tuning](#upload-modes--tuning).
+- **Non-fatal transient errors** — `429/503` and connection resets are retried/counted, not fatal.
+- **No-progress watchdog** — if the aggregate processed count doesn't advance for a few minutes (e.g. a hung
+  request on a half-open socket), the run aborts with a clear, re-runnable message instead of wedging.
+- **`maxRecords` cap** — copy a small sample first to validate; a capped run skips verification and the
+  cutover command, and logs that the target is a SAMPLE not to be promoted.
+- **Resume** — with `workers = 1` (a single full-range shard), pass the last logged cursor as `startAfterId`
+  to continue an interrupted run. With `workers > 1`, per-shard cursors make a single id meaningless, so it
+  is ignored — just re-run (uploads are **idempotent upserts** keyed by `id`).
 
-- **Keyset pagination** on the key (`orderby id asc` + `id gt '<cursor>'`) instead of `$skip`, which Azure
-  caps at 100,000 documents.
-- **Parallel sharded reads** — with `workers > 1` the UUID key space is split into 16 shards by leading hex
-  character and read concurrently, because the copy is dominated by per-page network round-trips while the
-  client sits idle.
-- A shared, thread-safe **buffered sender** that auto-batches, splits over-16 MB batches, and retries
-  throttling (429/503) — transient errors (e.g. `Connection reset` over a VPN) do **not** abort the run.
-- A **no-progress watchdog** so a genuinely hung request (e.g. a half-open socket) can never wedge the run
-  indefinitely — it aborts with a clear, re-runnable message instead.
-- A **`maxRecords` cap** to copy a small sample for validation before committing to a full run.
-
-> Throughput note: the copy is network-bound. Over a healthy/in-region path a full copy of ~340k documents
-> runs in the ~15-minute ballpark; over a degraded VPN/public-internet path it is slower and more prone to
-> connection resets. Running the tool **in the same Azure region** as the search service is the single
-> biggest lever for speed and stability.
-
----
-
-## What has changed (v1 → v2 schema)
-
-The migration's purpose is to apply the v2 schema. **Document data is copied verbatim — only the index
-field _attributes_ change.** The changes are "hygiene" (removing unused/ harmful flags) plus making
-`documentId` directly filterable. See the [field table](#fields-migrated) below for the per-field detail.
-
-Summary of the v2 changes:
-
-- **Only `chunk` stays `searchable`** — identifier/URL/metadata fields are no longer lexically searched, so
-  keyword queries can't match on a filename, URL or GUID.
-- **`sortable` / `facetable` removed everywhere** they were unused (`id` keeps `sortable` because the
-  migration's keyset pagination orders by it).
-- **`documentId` is now `filterable`** (forward-looking enablement; the application filter code is unchanged).
-- **`synonymMaps` removed** from non-searchable fields.
-- **`chunkVector`, `retrievable`, `stored`, `dimensions`, vector/semantic/similarity config are unchanged.**
-
-The tool also encodes several operational decisions:
+How it applies the schema:
 
 - **Alias-based cutover.** The pinned `azure-search-documents` Java SDK has **no index-alias API**, so the
   tool prints an `az rest` command (the data-plane REST API does support aliases) rather than calling the SDK.
 - **`SearchIndex` is immutable** (no `setName`), so the tool rewrites the schema JSON's `name` to the target
-  before parsing — every other property is preserved verbatim from the schema file.
-- **Sample runs are quarantined.** A `maxRecords`-capped run skips the full-count verification and does
-  **not** emit the cutover command, and logs that the target is a SAMPLE not to be promoted.
+  index before parsing — every other property is preserved verbatim from the schema file.
 
 ---
 
@@ -88,8 +64,8 @@ The tool also encodes several operational decisions:
 - Authenticated via `DefaultAzureCredential` — locally this means `az login` (the tool logs which credential
   it used). The principal needs **Search Service Contributor** (create index / read counts) and **Search
   Index Data Contributor** (read source docs, write target docs).
-- HTTP/retry behaviour is configurable via the usual `AZURE_CLIENT_*` / `HTTP_CLIENT_*` env vars (defaults
-  are sensible; the Netty response timeout defaults to 180s).
+- HTTP/retry and upload behaviour are tuned via env vars (see [Environment variables](#environment-variables));
+  defaults are backwards-compatible.
 
 ### Command
 
@@ -99,13 +75,20 @@ mvn -pl ai-document-migration-tool exec:java \
 ```
 
 ```bash
-# Full copy, 8 concurrent shards
+# Full copy, 8 concurrent shards (async, ample memory)
 mvn -pl ai-document-migration-tool exec:java \
   -Dexec.args="https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 8"
 
-# Sample copy of the first 20,000 records (for validation) — no verification, no cutover command
+# Sample copy of the first 20,000 records (validation) — no verification, no cutover command
 mvn -pl ai-document-migration-tool exec:java \
   -Dexec.args="https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 8 20000"
+
+# Low-memory / constrained host: sync uploads, 4 workers, heap capped at 1 GB
+MAVEN_OPTS="-Xmx1g -XX:+UseG1GC" \
+MIGRATION_UPLOAD_MODE=sync \
+HTTP_CLIENT_WRITE_TIMEOUT_IN_SECONDS=15 HTTP_CLIENT_READ_TIMEOUT_IN_SECONDS=10 HTTP_CLIENT_RESPONSE_TIMEOUT_IN_SECONDS=30 \
+mvn -pl ai-document-migration-tool exec:java \
+  -Dexec.args="https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 4"
 ```
 
 ### Arguments
@@ -115,42 +98,83 @@ mvn -pl ai-document-migration-tool exec:java \
 | 1 | `endpoint` | yes | — | Search service endpoint, e.g. `https://my-svc.search.windows.net` |
 | 2 | `sourceIndex` | yes | — | Existing index to copy **from** (e.g. `ai-rag-service-index`) |
 | 3 | `targetIndex` | yes | — | New index to create and copy **to** (e.g. `ai-rag-service-index-v2`) |
-| 4 | `aliasName` | yes | — | Alias name used in the printed cutover command (e.g. `ai-rag-service-index-alias`) |
+| 4 | `aliasName` | yes | — | Alias name used in the printed cutover command |
 | 5 | `schemaResourcePath` | yes | — | Classpath path to the v2 schema (`/vector-db-index-schema-v2.json`) |
 | 6 | `workers` | no | `8` | Concurrent shard readers; effective parallelism is `min(workers, 16)` |
 | 7 | `maxRecords` | no | `0` (all) | Global cap on documents copied — a positive value makes it a **sample** run |
 | 8 | `startAfterId` | no | — | Resume cursor (single-worker runs only; ignored when `workers > 1`) |
 
+Read page size and the async initial batch size are fixed at **250** (`DEFAULT_PAGE_SIZE`) — a 3072-float
+vector serialises to ~25–35 KB of JSON, so 250 keeps a batch (~7–9 MB) safely under Azure's 16 MB request
+limit. Don't raise it toward 500+ (risks `413` splits and larger per-request memory).
+
+### Environment variables
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `MIGRATION_UPLOAD_MODE` | `async` | `sync` selects the memory-bounded per-page uploader; anything else = async buffered sender |
+| `HTTP_CLIENT_WRITE_TIMEOUT_IN_SECONDS` | `60` | Bounds a stalled **outbound upload** (the usual connection-straggler cause) |
+| `HTTP_CLIENT_READ_TIMEOUT_IN_SECONDS` | `60` | Idle-read timeout — bounds a stalled response |
+| `HTTP_CLIENT_RESPONSE_TIMEOUT_IN_SECONDS` | `180` | Overall per-request ceiling |
+| `HTTP_CLIENT_CONNECT_TIMEOUT_IN_SECONDS` | `10` | TCP connect timeout |
+| `AZURE_CLIENT_MAX_RETRIES` | `3` | SDK retry attempts (keep — retries land a hung flush on a healthy connection) |
+
+> The timeout vars live in the shared `ClientConfiguration` (used by the deployed functions too), but all
+> defaults are unchanged, so lowering them only affects a run that explicitly sets them.
+
 ### Cutover
 
 A successful **full** run prints a ready-to-run `az rest` `PUT` that points the alias at the new index.
-After running it (allow ~10s to propagate and validating), set `AZURE_SEARCH_SERVICE_INDEX_NAME` to the
+After running it (allow ~10 s to propagate, and validate), set `AZURE_SEARCH_SERVICE_INDEX_NAME` to the
 **alias** in each environment's function settings. Future rebuilds become "build vN+1, repoint the alias"
 with no application change. Re-runs are safe — uploads are idempotent upserts keyed by `id`.
 
 ---
 
-## Fields migrated
+## Upload modes & tuning
 
-Every field is **copied as-is** (values unchanged); the table shows the **attribute changes** applied by the
-v2 schema. `retrievable` and `stored` remain `true` on all fields (required so the copy can read every field,
-including the vector, back out). ✅ = enabled in v2, ❌ = disabled in v2; **bold** marks a change from v1.
+The copy is network-bound; tune for **throughput** or **memory** depending on the host.
 
-| Field | Type | searchable | filterable | sortable | facetable | What changed & why |
-|-------|------|:----------:|:----------:|:--------:|:---------:|--------------------|
-| `id` (key) | `Edm.String` | ❌ | ✅ | ✅ | **❌** | Dropped unused `facetable`. Kept `filterable`+`sortable` — the migration keyset-paginates on `id`. |
-| `chunk` | `Edm.String` | ✅ | **❌** | **❌** | **❌** | The only lexically-searched field. Dropped unused filter/sort/facet on this large text body. |
-| `chunkVector` | `Collection(Edm.Single)` (3072) | ✅ | ❌ | ❌ | ❌ | **Unchanged.** Vector field; `retrievable`/`stored` true so it copies without re-embedding. |
-| `documentFileName` | `Edm.String` | **❌** | ❌ | **❌** | **❌** | No longer lexically searched (identifier, not prose); dropped unused sort/facet. |
-| `documentId` | `Edm.String` | **❌** | **✅** | **❌** | **❌** | Now directly `filterable` (enablement); no longer `searchable`; dropped unused sort/facet. |
-| `pageNumber` | `Edm.Int32` | ❌ | **❌** | **❌** | **❌** | Retrieved only; dropped unused filter/sort/facet. |
-| `chunkIndex` | `Edm.Int32` | ❌ | **❌** | **❌** | **❌** | Retrieved only; dropped unused filter/sort/facet. |
-| `documentFileUrl` | `Edm.String` | **❌** | **❌** | **❌** | **❌** | Citation field, retrieved only; dropped searchable/filter/sort/facet. |
-| `customMetadata/key` | `Edm.String` (complex) | **❌** | ✅ | ❌ | **❌** | Kept `filterable` (drives the `/any(...)` metadata filters); dropped searchable/facetable. |
-| `customMetadata/value` | `Edm.String` (complex) | **❌** | ✅ | ❌ | **❌** | Kept `filterable` (drives the `/any(...)` metadata filters); dropped searchable/facetable. |
+**`MIGRATION_UPLOAD_MODE=async` (default) — `BufferedSenderUploader`**
+Streams batches into a shared buffered sender that auto-batches, splits over-16 MB batches, retries
+throttling, and flushes in the background. **Highest throughput**, but it buffers on the producer side: if
+flushes lag reads (e.g. during connection stalls), the backlog grows. Needs **ample heap** — under a tight
+cap it can `OutOfMemoryError`. Use on a roomy box / in-region.
 
-> `synonymMaps: []` was also removed from every field except `chunk` (it only applies to searchable string
-> fields). Vector search (HNSW), semantic, and similarity (BM25) configuration are carried over unchanged.
+**`MIGRATION_UPLOAD_MODE=sync` — `SyncUploader`**
+Each worker uploads its page and blocks until indexed before reading the next. In-flight memory is bounded
+to **`workers × pageSize`** regardless of heap (no backlog), so it runs comfortably in a small heap (a full
+~340k copy completes under `-Xmx1g`). **Lower throughput** than async (no read/flush overlap). Use on a
+constrained host.
+
+Other knobs:
+
+- **`workers`** — `min(workers, 16)` shards run concurrently. More = faster (up to the service's capacity),
+  but more concurrent memory, more load on the service, and a higher chance of a slow connection straggler.
+  Use `2–4` on a weak box, `8` otherwise.
+- **Heap (`-Xmx`)** — with `async`, give it room; with `sync`, a small cap (e.g. `1g`) is enough. The
+  default (25 % of RAM) lets the JVM's RSS balloon on a big-RAM machine even though the live set is small.
+- **Timeouts** — over a flaky VPN, lower `HTTP_CLIENT_WRITE_TIMEOUT_IN_SECONDS` (and read/response) so a
+  stalled connection is abandoned and retried in seconds rather than ~minutes.
+- **In-region** — removes the VPN/internet path that causes the connection stalls; the biggest single lever.
+
+---
+
+## Known limitations & gotchas
+
+- **Verification is strict and eager.** `verifyCounts` compares `source == target` immediately after the
+  copy. This can report a **false mismatch** even when the copy is correct, because (a) Azure's document
+  count is **eventually consistent** — the target lags for seconds after the final upload — and (b) a **live
+  source drifts** (docs ingested during the run). Re-check `$count` on both indexes after they settle before
+  worrying; the target converges to `succeeded`. For a true cutover of a live source, either re-run (cheap —
+  idempotent upserts catch the drift) or quiesce source ingestion for a final pass.
+- **Connection stragglers over a VPN.** One worker's first upload connection can stall on a half-open socket
+  / handshake (tens of seconds up to ~3 min) while the others carry on; it self-recovers and the watchdog
+  bounds the worst case. Lower the write/read timeouts to shorten it; run in-region to avoid it.
+- **Storage size.** v2 ≈ v1 (the vectors dominate and are unchanged; the dropped auxiliary structures trim
+  only a small percentage). A freshly-loaded v2 may show transient bloat from repeated sample/partial
+  upserts until Azure's background merge reclaims the superseded versions. See
+  [SCHEMA_CHANGES.md](SCHEMA_CHANGES.md#storage-impact).
 
 ---
 
@@ -158,13 +182,22 @@ including the vector, back out). ✅ = enabled in v2, ❌ = disabled in v2; **bo
 
 | Class | Responsibility |
 |-------|----------------|
-| `IndexMigrationTool` | Entry point (`main`): parses args and wires the pieces together |
+| `IndexMigrationTool` | Entry point (`main`): parses args, selects the upload mode, wires the pieces together |
 | `IndexCopier` | The parallel copy engine: keyset pagination, the record cap, the stall watchdog, ETA |
 | `Shard` | A key-space slice: partitioning (`plan`) and OData range/keyset filter construction |
 | `SearchIndexAdmin` | Client/sender construction, target-index creation, count verification, cutover command |
+| `DocumentUploader` | Upload abstraction — swap throughput for memory without touching the engine |
+| `BufferedSenderUploader` | Async path: streams into the shared buffered sender (default) |
+| `SyncUploader` | Sync path: per-page upload, bounding in-flight memory to `workers × pageSize` |
 
 ### Build & test
 
 ```bash
 mvn -pl ai-document-migration-tool -am clean test
 ```
+
+---
+
+## Related docs
+
+- **[SCHEMA_CHANGES.md](SCHEMA_CHANGES.md)** — the v1 → v2 schema changes, per-field detail, and storage impact.

--- a/ai-document-migration-tool/SCHEMA_CHANGES.md
+++ b/ai-document-migration-tool/SCHEMA_CHANGES.md
@@ -1,0 +1,67 @@
+# v2 Index Schema Changes
+
+The [migration tool](README.md) rebuilds the Azure AI Search index with a corrected **v2 schema**, defined
+in `ai-document-shared-artefacts/src/main/resources/vector-db-index-schema-v2.json`. This document describes
+what changed from the original (v1) schema and why.
+
+**Document data is copied verbatim — only the index field _attributes_ change.**
+
+---
+
+## Why the schema changed
+
+The live index (`ai-rag-service-index`) was created with attribute flags that don't match how the service
+actually queries it:
+
+- identifier/URL fields were `searchable`, so a free-text query could match on a filename or GUID and
+  pollute relevance;
+- every field was `sortable`/`facetable` even though nothing ever sorts or facets.
+
+Those attributes (`searchable`, `filterable`, `sortable`, `facetable`, `stored`, `type`) are **immutable
+once an index holds data**, and Azure AI Search has **no native copy/backup**. So correcting them means
+standing up a new index with the fixed schema and re-populating it — which is exactly what the migration
+tool does.
+
+---
+
+## Summary of v2 changes
+
+- **Only `chunk` stays `searchable`** — identifier/URL/metadata fields are no longer lexically searched, so
+  keyword queries can't match on a filename, URL or GUID (tighter relevance, smaller inverted indexes).
+- **`sortable` / `facetable` removed everywhere** they were unused (`id` keeps `sortable` because the
+  migration's keyset pagination orders by it).
+- **`documentId` is now `filterable`** — forward-looking enablement; the application's filter code is
+  unchanged (it still filters via `customMetadata/any(...)`).
+- **`synonymMaps` removed** from every field except `chunk` (they only apply to searchable string fields).
+- **Unchanged:** `chunkVector` (incl. `dimensions`), `retrievable`, `stored`, and the vector (HNSW),
+  semantic, and similarity (BM25) configuration.
+
+---
+
+## Fields
+
+`retrievable` and `stored` remain `true` on all fields (required so the copy can read every field, including
+the vector, back out). ✅ = enabled in v2, ❌ = disabled in v2; **bold** marks a change from v1.
+
+| Field | Type | searchable | filterable | sortable | facetable | What changed & why |
+|-------|------|:----------:|:----------:|:--------:|:---------:|--------------------|
+| `id` (key) | `Edm.String` | ❌ | ✅ | ✅ | **❌** | Dropped unused `facetable`. Kept `filterable`+`sortable` — the migration keyset-paginates on `id`. |
+| `chunk` | `Edm.String` | ✅ | **❌** | **❌** | **❌** | The only lexically-searched field. Dropped unused filter/sort/facet on this large text body. |
+| `chunkVector` | `Collection(Edm.Single)` (3072) | ✅ | ❌ | ❌ | ❌ | **Unchanged.** Vector field; `retrievable`/`stored` true so it copies without re-embedding. |
+| `documentFileName` | `Edm.String` | **❌** | ❌ | **❌** | **❌** | No longer lexically searched (identifier, not prose); dropped unused sort/facet. |
+| `documentId` | `Edm.String` | **❌** | **✅** | **❌** | **❌** | Now directly `filterable` (enablement); no longer `searchable`; dropped unused sort/facet. |
+| `pageNumber` | `Edm.Int32` | ❌ | **❌** | **❌** | **❌** | Retrieved only; dropped unused filter/sort/facet. |
+| `chunkIndex` | `Edm.Int32` | ❌ | **❌** | **❌** | **❌** | Retrieved only; dropped unused filter/sort/facet. |
+| `documentFileUrl` | `Edm.String` | **❌** | **❌** | **❌** | **❌** | Citation field, retrieved only; dropped searchable/filter/sort/facet. |
+| `customMetadata/key` | `Edm.String` (complex) | **❌** | ✅ | ❌ | **❌** | Kept `filterable` (drives the `/any(...)` metadata filters); dropped searchable/facetable. |
+| `customMetadata/value` | `Edm.String` (complex) | **❌** | ✅ | ❌ | **❌** | Kept `filterable` (drives the `/any(...)` metadata filters); dropped searchable/facetable. |
+
+---
+
+## Storage impact
+
+Because `chunkVector` (3072-dim, `retrievable`+`stored`) is unchanged and the **vectors dominate storage**,
+v2's total size lands **close to v1's** — marginally smaller, as the dropped auxiliary structures (inverted
+indexes for the de-`searchable`d fields, plus the sort/facet structures) are trimmed. A freshly-loaded v2
+may briefly show extra size from repeated sample/partial upserts until Azure's background merge reclaims the
+superseded versions (see the README's "Known limitations & gotchas").

--- a/ai-document-migration-tool/pom.xml
+++ b/ai-document-migration-tool/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cp.azure.ragservice</groupId>
         <artifactId>cp-ai-rag-service</artifactId>
-        <version>17.0.81-SNAPSHOT</version>
+        <version>17.0.82-SNAPSHOT</version>
     </parent>
 
     <artifactId>ai-document-migration-tool</artifactId>

--- a/ai-document-migration-tool/pom.xml
+++ b/ai-document-migration-tool/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>uk.gov.moj.cp.azure.ragservice</groupId>
+        <artifactId>cp-ai-rag-service</artifactId>
+        <version>17.0.81-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>ai-document-migration-tool</artifactId>
+    <packaging>jar</packaging>
+    <name>AI Document Migration Tool</name>
+    <description>One-off, resumable index-to-index migration tool for rebuilding the Azure AI Search index with a new schema. Not deployed.</description>
+
+    <properties>
+        <exec.maven.plugin.version>3.1.0</exec.maven.plugin.version>
+        <migration.mainClass>uk.gov.moj.cp.migration.IndexMigrationTool</migration.mainClass>
+    </properties>
+
+    <dependencies>
+        <!-- Shared models, clients and utilities (AISearchClientFactory, CredentialUtil, ClientConfiguration, ChunkedEntry, IndexConstants, StringUtil) -->
+        <dependency>
+            <groupId>uk.gov.moj.cp.azure.ragservice</groupId>
+            <artifactId>ai-document-shared-artefacts</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Search data-plane + index-management clients (SearchClient, SearchIndexingBufferedSender,
+             SearchIndexClient, SearchIndex). Version managed by azure-sdk-bom. -->
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-search-documents</artifactId>
+        </dependency>
+
+        <!-- Test (junit + mockito inherited project-wide; assertj is managed-only, so declare it here) -->
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${exec.maven.plugin.version}</version>
+                <configuration>
+                    <mainClass>${migration.mainClass}</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/BufferedSenderUploader.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/BufferedSenderUploader.java
@@ -1,0 +1,31 @@
+package uk.gov.moj.cp.migration;
+
+import uk.gov.moj.cp.ai.model.ChunkedEntry;
+
+import java.util.List;
+
+import com.azure.search.documents.SearchIndexingBufferedSender;
+
+/**
+ * Async upload path: streams batches into the shared {@link SearchIndexingBufferedSender}, which auto-batches,
+ * splits over-16 MB batches, retries throttling (429/503), and flushes in the background. Highest throughput,
+ * but it buffers on the producer side — under a tight heap the backlog can grow faster than it flushes.
+ */
+final class BufferedSenderUploader implements DocumentUploader {
+
+    private final SearchIndexingBufferedSender<ChunkedEntry> sender;
+
+    BufferedSenderUploader(final SearchIndexingBufferedSender<ChunkedEntry> sender) {
+        this.sender = sender;
+    }
+
+    @Override
+    public void upload(final List<ChunkedEntry> docs) {
+        sender.addUploadActions(docs);
+    }
+
+    @Override
+    public void close() {
+        sender.close(); // flush all buffered actions and wait for completion
+    }
+}

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/DocumentUploader.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/DocumentUploader.java
@@ -1,0 +1,19 @@
+package uk.gov.moj.cp.migration;
+
+import uk.gov.moj.cp.ai.model.ChunkedEntry;
+
+import java.util.List;
+
+/**
+ * Sink for copied document batches. Two implementations let the migration trade throughput against memory:
+ * {@link BufferedSenderUploader} (async, higher throughput, unbounded producer-side buffering) and
+ * {@link SyncUploader} (per-page synchronous upload, bounding in-flight memory to {@code workers × pageSize}).
+ */
+interface DocumentUploader {
+
+    /** Uploads a batch of documents. May buffer (async) or block until indexed (sync). */
+    void upload(List<ChunkedEntry> docs);
+
+    /** Flushes any buffered work and releases resources. No-op for the synchronous uploader. */
+    void close();
+}

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/IndexCopier.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/IndexCopier.java
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import com.azure.core.util.Context;
 import com.azure.search.documents.SearchClient;
-import com.azure.search.documents.SearchIndexingBufferedSender;
 import com.azure.search.documents.models.SearchOptions;
 import com.azure.search.documents.models.SearchResult;
 import com.azure.search.documents.util.SearchPagedIterable;
@@ -48,7 +47,7 @@ final class IndexCopier {
     private static final Duration WATCHDOG_POLL = Duration.ofSeconds(15);
 
     private final SearchClient source;
-    private final SearchIndexingBufferedSender<ChunkedEntry> sender;
+    private final DocumentUploader uploader;
     private final int pageSize;
     private final int workers;
     private final long maxRecords; // <= 0 means copy everything; otherwise a global cap (sample copy)
@@ -61,12 +60,12 @@ final class IndexCopier {
     private long startNanos;     // set before workers start -> happens-before via task submission
 
     IndexCopier(final SearchClient source,
-                final SearchIndexingBufferedSender<ChunkedEntry> sender,
+                final DocumentUploader uploader,
                 final int pageSize,
                 final int workers,
                 final long maxRecords) {
         this.source = source;
-        this.sender = sender;
+        this.uploader = uploader;
         this.pageSize = pageSize;
         this.workers = Math.max(1, workers);
         this.maxRecords = maxRecords;
@@ -155,9 +154,9 @@ final class IndexCopier {
         }
         final long take = claim(valid.size()); // bumps submitted; trims to the remaining cap when limited
         if (take > 0) {
-            // Plain (async, non-fatal) flush: the sender batches, splits 16 MB, retries 429/503, and routes
-            // per-doc errors to onActionError — a transient flush error must not abort the run.
-            sender.addUploadActions(take == valid.size() ? valid : valid.subList(0, (int) take));
+            // The uploader is either async (buffered sender) or sync (per-page, memory-bounded); either way a
+            // transient per-doc error is counted, not fatal.
+            uploader.upload(take == valid.size() ? valid : valid.subList(0, (int) take));
         }
         return take < valid.size();
     }

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/IndexCopier.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/IndexCopier.java
@@ -1,0 +1,291 @@
+package uk.gov.moj.cp.migration;
+
+import static java.lang.String.format;
+import static uk.gov.moj.cp.ai.index.IndexConstants.ID;
+import static uk.gov.moj.cp.ai.util.StringUtil.escapeODataStringLiteral;
+
+import uk.gov.moj.cp.ai.model.ChunkedEntry;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.azure.core.util.Context;
+import com.azure.search.documents.SearchClient;
+import com.azure.search.documents.SearchIndexingBufferedSender;
+import com.azure.search.documents.models.SearchOptions;
+import com.azure.search.documents.models.SearchResult;
+import com.azure.search.documents.util.SearchPagedIterable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The parallel copy engine. Reads the source via keyset pagination — a single full-range scan with one
+ * worker, or 16 concurrent {@link Shard}s on a fixed pool — and streams valid chunks into the shared
+ * buffered sender. Tracks aggregate progress for the ETA, honours an optional global record cap, and
+ * runs a no-progress watchdog so a hung request can never wedge the run indefinitely.
+ */
+final class IndexCopier {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IndexCopier.class);
+
+    /** Embedding dimension; chunks whose stored vector doesn't match are skipped (surfaced via count check). */
+    static final int VECTOR_DIMENSIONS = 3072;
+
+    /** Watchdog backstop: abort if the aggregate processed count doesn't advance for this long — a true
+     *  hang (e.g. a half-open socket parking a flush) can never wedge the run. Sized above plausible
+     *  all-workers-throttling back-off to avoid false aborts. */
+    private static final Duration STALL_TIMEOUT = Duration.ofMinutes(3);
+
+    /** How long to block on a worker before re-checking the stall watchdog. */
+    private static final Duration WATCHDOG_POLL = Duration.ofSeconds(15);
+
+    private final SearchClient source;
+    private final SearchIndexingBufferedSender<ChunkedEntry> sender;
+    private final int pageSize;
+    private final int workers;
+    private final long maxRecords; // <= 0 means copy everything; otherwise a global cap (sample copy)
+
+    // Shared across worker threads for aggregate progress / ETA.
+    private final AtomicLong submitted = new AtomicLong();
+    private final AtomicLong skipped = new AtomicLong();
+    private long total;          // ETA denominator (min of source size and maxRecords)
+    private long baseProcessed;  // docs already copied before this run (resume), for the ETA
+    private long startNanos;     // set before workers start -> happens-before via task submission
+
+    IndexCopier(final SearchClient source,
+                final SearchIndexingBufferedSender<ChunkedEntry> sender,
+                final int pageSize,
+                final int workers,
+                final long maxRecords) {
+        this.source = source;
+        this.sender = sender;
+        this.pageSize = pageSize;
+        this.workers = Math.max(1, workers);
+        this.maxRecords = maxRecords;
+    }
+
+    private boolean limited() {
+        return maxRecords > 0;
+    }
+
+    /**
+     * Copies documents from the source to the target. With one worker this is a single sequential keyset
+     * scan (resumable via {@code startAfterId}); with more, the key space is split into 16 shards read
+     * concurrently. All workers stream into the shared buffered sender.
+     *
+     * @return the number of documents submitted (valid vectors only, capped at {@code maxRecords}).
+     */
+    long copyAllDocuments(final String startAfterId) {
+        final long sourceCount = source.getDocumentCount();
+        total = limited() ? Math.min(sourceCount, maxRecords) : sourceCount;
+        baseProcessed = countProcessedBefore(startAfterId);
+        startNanos = System.nanoTime();
+        submitted.set(0);
+        skipped.set(0);
+
+        final List<Shard> shards = Shard.plan(workers, startAfterId);
+        final int poolSize = Math.min(this.workers, shards.size());
+        if (limited()) {
+            LOGGER.info("Copying up to {} record(s) (SAMPLE of {}) using {} worker(s) over {} shard(s).",
+                    maxRecords, sourceCount, poolSize, shards.size());
+        } else {
+            LOGGER.info("Copying {} document(s) using {} worker(s) over {} shard(s).",
+                    sourceCount, poolSize, shards.size());
+        }
+
+        try (ExecutorService pool = Executors.newFixedThreadPool(poolSize)) {
+            final List<Future<?>> futures = new ArrayList<>(shards.size());
+            for (final Shard shard : shards) {
+                futures.add(pool.submit(() -> copyShard(shard)));
+            }
+            awaitWithWatchdog(futures);
+        }
+
+        LOGGER.info("Read complete — {} submitted ({} skipped) across {} shard(s).",
+                submitted.get(), skipped.get(), shards.size());
+        return submitted.get();
+    }
+
+    /** Reads one shard end-to-end via keyset pagination, streaming valid chunks to the shared sender. */
+    private void copyShard(final Shard shard) {
+        final String label = shard.label();
+        String lastId = shard.startCursor();
+
+        while (true) {
+            if (limited() && submitted.get() >= maxRecords) {
+                break; // global record cap already reached by another shard
+            }
+            final List<ChunkedEntry> page = readPage(shard, lastId);
+            if (page.isEmpty()) {
+                break;
+            }
+            final List<ChunkedEntry> valid = page.stream().filter(IndexCopier::hasValidVector).toList();
+            final long pageSkipped = page.size() - (long) valid.size();
+            if (pageSkipped > 0) {
+                skipped.addAndGet(pageSkipped);
+                LOGGER.warn("[shard {}] skipped {} chunk(s) with a missing/wrong-size vector (expected {} dims).",
+                        label, pageSkipped, VECTOR_DIMENSIONS);
+            }
+            boolean capReached = false;
+            if (!valid.isEmpty()) {
+                final long take = claim(valid.size()); // bumps submitted; trims to the remaining cap when limited
+                if (take > 0) {
+                    final List<ChunkedEntry> toSend = take == valid.size() ? valid : valid.subList(0, (int) take);
+                    // Plain (async, non-fatal) flush: the sender batches, splits 16 MB, retries 429/503, and
+                    // routes per-doc errors to onActionError — a transient flush error must not abort the run.
+                    sender.addUploadActions(toSend);
+                }
+                capReached = take < valid.size();
+            }
+            lastId = page.get(page.size() - 1).id(); // advance by the raw page's last id (filtered rows kept in order)
+
+            final long processedThisRun = submitted.get() + skipped.get();
+            final long processedOverall = baseProcessed + processedThisRun;
+            final long remaining = Math.max(0, total - processedOverall);
+            LOGGER.info("[shard {}] Read to cursor id={}; {} submitted, {} skipped so far. "
+                            + "Est. time remaining: {} ({}/{} processed).",
+                    label, lastId, submitted.get(), skipped.get(),
+                    formatEta(processedThisRun, remaining, System.nanoTime() - startNanos),
+                    processedOverall, total);
+
+            if (capReached) {
+                LOGGER.info("[shard {}] record cap of {} reached; stopping.", label, maxRecords);
+                break;
+            }
+            if (page.size() < pageSize) {
+                break; // last (partial) page for this shard
+            }
+        }
+    }
+
+    /**
+     * Atomically reserves up to {@code want} slots against the run, returning how many may be uploaded.
+     * Unlimited runs always grant {@code want}; a limited run grants only the remaining budget so the global
+     * cap is honoured exactly without overshoot across concurrent shards. Bumps the {@code submitted} counter.
+     */
+    private long claim(final int want) {
+        if (!limited()) {
+            submitted.addAndGet(want);
+            return want;
+        }
+        while (true) {
+            final long current = submitted.get();
+            if (current >= maxRecords) {
+                return 0;
+            }
+            final long take = Math.min(want, maxRecords - current);
+            if (submitted.compareAndSet(current, current + take)) {
+                return take;
+            }
+        }
+    }
+
+    /**
+     * Waits for all shard workers, surfacing the first failure, and aborts if the aggregate processed count
+     * doesn't advance for {@link #STALL_TIMEOUT}. On any abnormal exit the remaining workers are cancelled
+     * so the pool terminates promptly.
+     */
+    private void awaitWithWatchdog(final List<Future<?>> futures) {
+        long lastProcessed = -1;
+        long lastProgressNanos = System.nanoTime();
+        try {
+            for (final Future<?> future : futures) {
+                while (true) {
+                    try {
+                        future.get(WATCHDOG_POLL.toMillis(), TimeUnit.MILLISECONDS);
+                        break; // this shard finished successfully
+                    } catch (final TimeoutException waiting) {
+                        final long processed = submitted.get() + skipped.get();
+                        if (processed != lastProcessed) {
+                            lastProcessed = processed;
+                            lastProgressNanos = System.nanoTime();
+                        } else if (System.nanoTime() - lastProgressNanos > STALL_TIMEOUT.toNanos()) {
+                            throw new IllegalStateException(format(
+                                    "Migration stalled: no progress for %d min (processed %d/%d). Likely a hung "
+                                            + "request — re-run to recover (uploads are idempotent).",
+                                    STALL_TIMEOUT.toMinutes(), processed, total));
+                        }
+                    }
+                }
+            }
+        } catch (final InterruptedException e) {
+            cancelAll(futures);
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Migration interrupted", e);
+        } catch (final ExecutionException e) {
+            cancelAll(futures);
+            throw new IllegalStateException("A migration worker failed", e.getCause());
+        } catch (final RuntimeException e) {
+            cancelAll(futures); // stall (or any unexpected) — stop the rest before surfacing
+            throw e;
+        }
+    }
+
+    private static void cancelAll(final List<Future<?>> futures) {
+        futures.forEach(future -> future.cancel(true));
+    }
+
+    /**
+     * Reads one keyset page for {@code shard}, ordered by {@code id} ascending, starting after
+     * {@code lastId}. No {@code setSelect} is used so every retrievable field is pulled, including
+     * {@code chunkIndex} which the retrieval query path drops.
+     */
+    List<ChunkedEntry> readPage(final Shard shard, final String lastId) {
+        final SearchOptions options = new SearchOptions()
+                .setTop(pageSize)
+                .setOrderBy(ID + " asc"); // requires id sortable
+        final String filter = shard.pageFilter(lastId);
+        if (filter != null) {
+            options.setFilter(filter); // requires id filterable
+        }
+
+        final SearchPagedIterable results = source.search("*", options, Context.NONE);
+        final List<ChunkedEntry> page = new ArrayList<>(pageSize);
+        for (final SearchResult result : results) {
+            page.add(result.getDocument(ChunkedEntry.class));
+        }
+        return page;
+    }
+
+    private static boolean hasValidVector(final ChunkedEntry entry) {
+        return entry.chunkVector() != null && entry.chunkVector().size() == VECTOR_DIMENSIONS;
+    }
+
+    /**
+     * Count of source documents already copied (id ≤ cursor) when resuming a single-worker run, so the ETA
+     * "processed"/"remaining" are correct mid-stream. Returns 0 on a fresh run or any multi-worker run.
+     */
+    private long countProcessedBefore(final String startAfterId) {
+        if (workers > 1 || startAfterId == null || startAfterId.isEmpty()) {
+            return 0;
+        }
+        final SearchOptions options = new SearchOptions()
+                .setFilter(format("%s le '%s'", ID, escapeODataStringLiteral(startAfterId)))
+                .setTop(0)
+                .setIncludeTotalCount(true);
+        final Long count = source.search("*", options, Context.NONE).getTotalCount();
+        return count == null ? 0 : count;
+    }
+
+    /**
+     * Formats an ETA as {@code HH:MM:SS} from this run's throughput: {@code processedThisRun} over
+     * {@code elapsedNanos} gives a per-record rate, projected across the {@code remaining} records (hours
+     * are not capped at 24). Returns "unknown" before any progress is measurable.
+     */
+    static String formatEta(final long processedThisRun, final long remaining, final long elapsedNanos) {
+        if (processedThisRun <= 0 || elapsedNanos <= 0) {
+            return "unknown";
+        }
+        final long etaNanos = (long) ((double) elapsedNanos / processedThisRun * remaining);
+        final Duration eta = Duration.ofNanos(etaNanos);
+        return format("%02d:%02d:%02d", eta.toHours(), eta.toMinutesPart(), eta.toSecondsPart());
+    }
+}

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/IndexCopier.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/IndexCopier.java
@@ -119,44 +119,16 @@ final class IndexCopier {
         final String label = shard.label();
         String lastId = shard.startCursor();
 
-        while (true) {
-            if (limited() && submitted.get() >= maxRecords) {
-                break; // global record cap already reached by another shard
-            }
+        while (!capReachedGlobally()) {
             final List<ChunkedEntry> page = readPage(shard, lastId);
             if (page.isEmpty()) {
                 break;
             }
-            final List<ChunkedEntry> valid = page.stream().filter(IndexCopier::hasValidVector).toList();
-            final long pageSkipped = page.size() - (long) valid.size();
-            if (pageSkipped > 0) {
-                skipped.addAndGet(pageSkipped);
-                LOGGER.warn("[shard {}] skipped {} chunk(s) with a missing/wrong-size vector (expected {} dims).",
-                        label, pageSkipped, VECTOR_DIMENSIONS);
-            }
-            boolean capReached = false;
-            if (!valid.isEmpty()) {
-                final long take = claim(valid.size()); // bumps submitted; trims to the remaining cap when limited
-                if (take > 0) {
-                    final List<ChunkedEntry> toSend = take == valid.size() ? valid : valid.subList(0, (int) take);
-                    // Plain (async, non-fatal) flush: the sender batches, splits 16 MB, retries 429/503, and
-                    // routes per-doc errors to onActionError — a transient flush error must not abort the run.
-                    sender.addUploadActions(toSend);
-                }
-                capReached = take < valid.size();
-            }
+            final boolean capHit = uploadPage(page, label);
             lastId = page.get(page.size() - 1).id(); // advance by the raw page's last id (filtered rows kept in order)
+            logProgress(label, lastId);
 
-            final long processedThisRun = submitted.get() + skipped.get();
-            final long processedOverall = baseProcessed + processedThisRun;
-            final long remaining = Math.max(0, total - processedOverall);
-            LOGGER.info("[shard {}] Read to cursor id={}; {} submitted, {} skipped so far. "
-                            + "Est. time remaining: {} ({}/{} processed).",
-                    label, lastId, submitted.get(), skipped.get(),
-                    formatEta(processedThisRun, remaining, System.nanoTime() - startNanos),
-                    processedOverall, total);
-
-            if (capReached) {
+            if (capHit) {
                 LOGGER.info("[shard {}] record cap of {} reached; stopping.", label, maxRecords);
                 break;
             }
@@ -164,6 +136,49 @@ final class IndexCopier {
                 break; // last (partial) page for this shard
             }
         }
+    }
+
+    /** True once the global record cap has been reached (by this or another shard). */
+    private boolean capReachedGlobally() {
+        return limited() && submitted.get() >= maxRecords;
+    }
+
+    /**
+     * Filters a page to valid-vector chunks, records skips, claims budget, and streams the claimed slice to
+     * the shared sender. Returns {@code true} if the global cap was hit mid-page (i.e. the page was trimmed).
+     */
+    private boolean uploadPage(final List<ChunkedEntry> page, final String label) {
+        final List<ChunkedEntry> valid = page.stream().filter(IndexCopier::hasValidVector).toList();
+        recordSkips(page.size() - (long) valid.size(), label);
+        if (valid.isEmpty()) {
+            return false;
+        }
+        final long take = claim(valid.size()); // bumps submitted; trims to the remaining cap when limited
+        if (take > 0) {
+            // Plain (async, non-fatal) flush: the sender batches, splits 16 MB, retries 429/503, and routes
+            // per-doc errors to onActionError — a transient flush error must not abort the run.
+            sender.addUploadActions(take == valid.size() ? valid : valid.subList(0, (int) take));
+        }
+        return take < valid.size();
+    }
+
+    private void recordSkips(final long pageSkipped, final String label) {
+        if (pageSkipped > 0) {
+            skipped.addAndGet(pageSkipped);
+            LOGGER.warn("[shard {}] skipped {} chunk(s) with a missing/wrong-size vector (expected {} dims).",
+                    label, pageSkipped, VECTOR_DIMENSIONS);
+        }
+    }
+
+    private void logProgress(final String label, final String lastId) {
+        final long processedThisRun = submitted.get() + skipped.get();
+        final long processedOverall = baseProcessed + processedThisRun;
+        final long remaining = Math.max(0, total - processedOverall);
+        LOGGER.info("[shard {}] Read to cursor id={}; {} submitted, {} skipped so far. "
+                        + "Est. time remaining: {} ({}/{} processed).",
+                label, lastId, submitted.get(), skipped.get(),
+                formatEta(processedThisRun, remaining, System.nanoTime() - startNanos),
+                processedOverall, total);
     }
 
     /**

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/IndexMigrationTool.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/IndexMigrationTool.java
@@ -3,12 +3,10 @@ package uk.gov.moj.cp.migration;
 import static java.lang.String.format;
 
 import uk.gov.moj.cp.ai.client.AISearchClientFactory;
-import uk.gov.moj.cp.ai.model.ChunkedEntry;
 
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.azure.search.documents.SearchClient;
-import com.azure.search.documents.SearchIndexingBufferedSender;
 import com.azure.search.documents.indexes.SearchIndexClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +57,7 @@ public final class IndexMigrationTool {
     /** Read page size, and the buffered sender's initial batch size. A 3072-float vector serialises to
      *  ~25-35 KB of JSON, so ~500 keeps the initial batch under the 16 MB request limit; the sender
      *  auto-splits anyway if a batch is rejected with 413. */
-    static final int DEFAULT_PAGE_SIZE = 500;
+    static final int DEFAULT_PAGE_SIZE = 250;
 
     /** Default concurrent shard readers. Capped to the shard count (16) at runtime. */
     static final int DEFAULT_WORKERS = 8;
@@ -87,15 +85,15 @@ public final class IndexMigrationTool {
         final SearchClient sourceClient = AISearchClientFactory.getInstance(endpoint, sourceIndex);
         final AtomicLong succeeded = new AtomicLong();
         final AtomicLong failed = new AtomicLong();
-        final SearchIndexingBufferedSender<ChunkedEntry> sender =
-                SearchIndexAdmin.bufferedSender(endpoint, targetIndex, DEFAULT_PAGE_SIZE, succeeded, failed);
+        final DocumentUploader uploader =
+                uploader(System.getenv("MIGRATION_UPLOAD_MODE"), endpoint, targetIndex, DEFAULT_PAGE_SIZE, succeeded, failed);
 
         final long submitted;
         try {
-            submitted = new IndexCopier(sourceClient, sender, DEFAULT_PAGE_SIZE, workers, maxRecords)
+            submitted = new IndexCopier(sourceClient, uploader, DEFAULT_PAGE_SIZE, workers, maxRecords)
                     .copyAllDocuments(startAfterId);
         } finally {
-            sender.close(); // flush all buffered actions from every worker and wait for completion
+            uploader.close(); // flush/await (async) or no-op (sync)
         }
         LOGGER.info("Indexing finished — submitted={}, succeeded={}, failed={}.",
                 submitted, succeeded.get(), failed.get());
@@ -115,5 +113,21 @@ public final class IndexMigrationTool {
         SearchIndexAdmin.verifyCounts(indexClient, sourceIndex, targetIndex, succeeded.get());
         SearchIndexAdmin.logCutoverCommand(endpoint, aliasName, targetIndex);
         LOGGER.info("Migration complete. Target index '{}' is populated and verified.", targetIndex);
+    }
+
+    /**
+     * Chooses the upload strategy from {@code MIGRATION_UPLOAD_MODE}: {@code "sync"} → {@link SyncUploader}
+     * (per-page, memory-bounded — for constrained hosts); anything else (default) → {@link BufferedSenderUploader}
+     * (async buffered sender, higher throughput). Lets you switch without a rebuild and revert easily.
+     */
+    static DocumentUploader uploader(final String mode, final String endpoint, final String targetIndex,
+                                     final int batchSize, final AtomicLong succeeded, final AtomicLong failed) {
+        if ("sync".equalsIgnoreCase(mode)) {
+            LOGGER.info("Upload mode: SYNC (per-page; in-flight memory bounded to workers x pageSize).");
+            return new SyncUploader(AISearchClientFactory.getInstance(endpoint, targetIndex), succeeded, failed);
+        }
+        LOGGER.info("Upload mode: ASYNC (buffered sender).");
+        return new BufferedSenderUploader(
+                SearchIndexAdmin.bufferedSender(endpoint, targetIndex, batchSize, succeeded, failed));
     }
 }

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/IndexMigrationTool.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/IndexMigrationTool.java
@@ -1,0 +1,119 @@
+package uk.gov.moj.cp.migration;
+
+import static java.lang.String.format;
+
+import uk.gov.moj.cp.ai.client.AISearchClientFactory;
+import uk.gov.moj.cp.ai.model.ChunkedEntry;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.azure.search.documents.SearchClient;
+import com.azure.search.documents.SearchIndexingBufferedSender;
+import com.azure.search.documents.indexes.SearchIndexClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * One-off, resumable index-to-index migration for a populated Azure AI Search index — the entry point that
+ * wires together {@link SearchIndexAdmin} (client/index management) and {@link IndexCopier} (the copy
+ * engine, which partitions the key space into {@link Shard}s).
+ *
+ * <p>Azure AI Search cannot change immutable field attributes (searchable / filterable / sortable /
+ * facetable / stored / type) on an existing index, and has no native copy/backup feature. This tool
+ * performs a drop-free rebuild: it creates a new index from a v2 schema, copies every document across
+ * (vectors included — no re-embedding, because all fields are retrievable), verifies the document
+ * counts match, then prints the alias create/repoint command for a zero-downtime cutover (the pinned
+ * Java SDK has no index-alias API, so the alias step is run via the data-plane REST API / {@code az rest}).</p>
+ *
+ * <p><strong>Reads</strong> use keyset pagination on the key field rather than {@code $skip} (Azure caps
+ * {@code $skip} at 100,000). With {@code workers > 1} the key space is split into 16 shards read
+ * concurrently. <strong>Writes</strong> stream into a single thread-safe {@link SearchIndexingBufferedSender}
+ * shared by all workers, which auto-batches, splits over-16 MB batches, retries throttling (429/503), and
+ * flushes asynchronously.</p>
+ *
+ * <p>Resume: with {@code workers = 1} pass the last logged cursor id as {@code startAfterId} to continue an
+ * interrupted run. With {@code workers > 1} it is ignored — just re-run, since uploads are idempotent
+ * upserts keyed by {@code id}.</p>
+ *
+ * <p>{@code maxRecords} caps the total number of documents copied — pass e.g. {@code 20000} to copy a
+ * sample for testing. It's a global cap across shards (with one worker it's the first N by id; with more,
+ * ~N spread across the key space). A capped run is a deliberate subset, so it skips the full-count
+ * verification and does NOT emit the alias-cutover command. {@code 0} (default) copies everything.</p>
+ *
+ * <p>Usage (managed-identity / {@code az login} credential is used automatically):</p>
+ * <pre>
+ *   mvn -pl ai-document-migration-tool exec:java \
+ *     -Dexec.args="&lt;endpoint&gt; &lt;sourceIndex&gt; &lt;targetIndex&gt; &lt;aliasName&gt; &lt;schemaResourcePath&gt; [workers] [maxRecords] [startAfterId]"
+ *
+ *   # full copy, 8 concurrent shards
+ *   ... -Dexec.args="https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 8"
+ *
+ *   # sample copy of the first 20000 records, 8 workers
+ *   ... -Dexec.args="https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 8 20000"
+ * </pre>
+ */
+public final class IndexMigrationTool {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IndexMigrationTool.class);
+
+    /** Read page size, and the buffered sender's initial batch size. A 3072-float vector serialises to
+     *  ~25-35 KB of JSON, so ~500 keeps the initial batch under the 16 MB request limit; the sender
+     *  auto-splits anyway if a batch is rejected with 413. */
+    static final int DEFAULT_PAGE_SIZE = 500;
+
+    /** Default concurrent shard readers. Capped to the shard count (16) at runtime. */
+    static final int DEFAULT_WORKERS = 8;
+
+    private IndexMigrationTool() {
+    }
+
+    public static void main(final String[] args) throws Exception {
+        if (args.length < 5) {
+            throw new IllegalArgumentException("Usage: <endpoint> <sourceIndex> <targetIndex> <aliasName> "
+                    + "<schemaResourcePath> [workers] [maxRecords] [startAfterId]");
+        }
+        final String endpoint = args[0];
+        final String sourceIndex = args[1];
+        final String targetIndex = args[2];
+        final String aliasName = args[3];
+        final String schemaResource = args[4];
+        final int workers = args.length > 5 ? Integer.parseInt(args[5]) : DEFAULT_WORKERS;
+        final long maxRecords = args.length > 6 ? Long.parseLong(args[6]) : 0; // 0 = copy everything
+        final String startAfterId = args.length > 7 ? args[7] : null;
+
+        final SearchIndexClient indexClient = SearchIndexAdmin.indexClient(endpoint);
+        SearchIndexAdmin.createTargetIndex(indexClient, targetIndex, schemaResource);
+
+        final SearchClient sourceClient = AISearchClientFactory.getInstance(endpoint, sourceIndex);
+        final AtomicLong succeeded = new AtomicLong();
+        final AtomicLong failed = new AtomicLong();
+        final SearchIndexingBufferedSender<ChunkedEntry> sender =
+                SearchIndexAdmin.bufferedSender(endpoint, targetIndex, DEFAULT_PAGE_SIZE, succeeded, failed);
+
+        final long submitted;
+        try {
+            submitted = new IndexCopier(sourceClient, sender, DEFAULT_PAGE_SIZE, workers, maxRecords)
+                    .copyAllDocuments(startAfterId);
+        } finally {
+            sender.close(); // flush all buffered actions from every worker and wait for completion
+        }
+        LOGGER.info("Indexing finished — submitted={}, succeeded={}, failed={}.",
+                submitted, succeeded.get(), failed.get());
+        if (failed.get() > 0) {
+            throw new IllegalStateException(
+                    format("%d document(s) failed to index. Investigate before cutover.", failed.get()));
+        }
+
+        if (maxRecords > 0) {
+            // Sample copy: target intentionally holds a subset, so the full-count check and cutover don't apply.
+            LOGGER.info("Partial copy complete — {} record(s) copied into '{}'. This is a SAMPLE dataset; "
+                    + "it is NOT verified against the full source and must NOT be used for alias cutover.",
+                    submitted, targetIndex);
+            return;
+        }
+
+        SearchIndexAdmin.verifyCounts(indexClient, sourceIndex, targetIndex, succeeded.get());
+        SearchIndexAdmin.logCutoverCommand(endpoint, aliasName, targetIndex);
+        LOGGER.info("Migration complete. Target index '{}' is populated and verified.", targetIndex);
+    }
+}

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/SearchIndexAdmin.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/SearchIndexAdmin.java
@@ -1,0 +1,131 @@
+package uk.gov.moj.cp.migration;
+
+import static java.lang.String.format;
+
+import uk.gov.moj.cp.ai.client.config.ClientConfiguration;
+import uk.gov.moj.cp.ai.model.ChunkedEntry;
+import uk.gov.moj.cp.ai.util.CredentialUtil;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.azure.core.util.serializer.TypeReference;
+import com.azure.json.JsonProviders;
+import com.azure.search.documents.SearchClientBuilder;
+import com.azure.search.documents.SearchIndexingBufferedSender;
+import com.azure.search.documents.indexes.SearchIndexClient;
+import com.azure.search.documents.indexes.SearchIndexClientBuilder;
+import com.azure.search.documents.indexes.models.SearchIndex;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Index management and client construction for the migration: the index-level client, the buffered sender,
+ * creating the target index from a v2 schema, verifying source/target counts, and emitting the
+ * alias-cutover command. All managed-identity authenticated via the shared credential.
+ */
+final class SearchIndexAdmin {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SearchIndexAdmin.class);
+
+    private static final int MAX_RETRIES_PER_ACTION = 3;
+    private static final Duration AUTO_FLUSH_INTERVAL = Duration.ofSeconds(10);
+
+    private SearchIndexAdmin() {
+    }
+
+    static SearchIndexClient indexClient(final String endpoint) {
+        return new SearchIndexClientBuilder()
+                .endpoint(endpoint)
+                .credential(CredentialUtil.getCredentialInstance())
+                .retryOptions(ClientConfiguration.getRetryOptions())
+                .httpClient(ClientConfiguration.createNettyClient())
+                .buildClient();
+    }
+
+    static SearchIndexingBufferedSender<ChunkedEntry> bufferedSender(final String endpoint,
+                                                                     final String indexName,
+                                                                     final int initialBatchActionCount,
+                                                                     final AtomicLong succeeded,
+                                                                     final AtomicLong failed) {
+        return new SearchClientBuilder()
+                .endpoint(endpoint)
+                .indexName(indexName)
+                .credential(CredentialUtil.getCredentialInstance())
+                .retryOptions(ClientConfiguration.getRetryOptions())
+                .httpClient(ClientConfiguration.createNettyClient())
+                .bufferedSender(TypeReference.createInstance(ChunkedEntry.class))
+                .documentKeyRetriever(ChunkedEntry::id)
+                .initialBatchActionCount(initialBatchActionCount)
+                .maxRetriesPerAction(MAX_RETRIES_PER_ACTION)
+                .autoFlushInterval(AUTO_FLUSH_INTERVAL)
+                .onActionSucceeded(options -> succeeded.incrementAndGet())
+                .onActionError(options -> {
+                    failed.incrementAndGet();
+                    LOGGER.error("Indexing action failed for document", options.getThrowable());
+                })
+                .buildSender();
+    }
+
+    static void createTargetIndex(final SearchIndexClient indexClient,
+                                  final String targetIndex,
+                                  final String schemaResource) throws Exception {
+        // SearchIndex is immutable (no setName), and the index name comes from the JSON, so override
+        // the "name" field to the desired physical target before parsing. Every other property
+        // (vectorSearch, semantic, similarity, fields...) is preserved verbatim from the schema file.
+        final SearchIndex index = SearchIndex.fromJson(
+                JsonProviders.createReader(loadSchemaWithName(schemaResource, targetIndex)));
+        indexClient.createOrUpdateIndex(index);
+        LOGGER.info("Created/updated target index '{}' from schema '{}'.", targetIndex, schemaResource);
+    }
+
+    static String loadSchemaWithName(final String schemaResource, final String targetIndex) throws Exception {
+        try (InputStream in = SearchIndexAdmin.class.getResourceAsStream(schemaResource)) {
+            if (in == null) {
+                throw new IllegalStateException("Schema resource not found on classpath: " + schemaResource);
+            }
+            final ObjectMapper mapper = new ObjectMapper();
+            final ObjectNode root = (ObjectNode) mapper.readTree(new String(in.readAllBytes(), StandardCharsets.UTF_8));
+            root.put("name", targetIndex);
+            return mapper.writeValueAsString(root);
+        }
+    }
+
+    static void verifyCounts(final SearchIndexClient indexClient,
+                             final String sourceIndex,
+                             final String targetIndex,
+                             final long succeeded) {
+        final long src = indexClient.getSearchClient(sourceIndex).getDocumentCount();
+        final long dst = indexClient.getSearchClient(targetIndex).getDocumentCount();
+        LOGGER.info("Verification — source={}, target={}, indexed={}.", src, dst, succeeded);
+        if (src != dst) {
+            throw new IllegalStateException(format(
+                    "Document count mismatch: source=%d target=%d. A chunk may have been skipped by the "
+                            + "vector validity check. Investigate before cutover.", src, dst));
+        }
+    }
+
+    /**
+     * Emits the alias create/repoint command for the cutover. The pinned azure-search-documents Java SDK
+     * has no index-alias API, but the data-plane REST API does — so this is run as an ops step
+     * ({@code az rest} below, or the portal). Idempotent {@code PUT}; allow ~10s to propagate before
+     * relying on the alias for queries. {@code --resource https://search.azure.com} acquires an AAD token
+     * for the search data plane via the same managed-identity / {@code az login} credential the tool uses.
+     */
+    static void logCutoverCommand(final String endpoint, final String aliasName, final String targetIndex) {
+        final String trimmed = endpoint.endsWith("/") ? endpoint.substring(0, endpoint.length() - 1) : endpoint;
+        LOGGER.info("Copy verified. Final cutover step — point the alias at '{}' (the Java SDK has no alias API; "
+                + "run this REST call):\n\n"
+                + "az rest --method put \\\n"
+                + "  --uri \"{}/aliases/{}?api-version=2024-07-01\" \\\n"
+                + "  --resource \"https://search.azure.com\" \\\n"
+                + "  --headers \"Content-Type=application/json\" \\\n"
+                + "  --body '{\"name\":\"{}\",\"indexes\":[\"{}\"]}'\n\n"
+                + "Then set AZURE_SEARCH_SERVICE_INDEX_NAME to '{}' in each environment's function settings.",
+                targetIndex, trimmed, aliasName, aliasName, targetIndex, aliasName);
+    }
+}

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/Shard.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/Shard.java
@@ -1,0 +1,76 @@
+package uk.gov.moj.cp.migration;
+
+import static java.lang.String.format;
+import static uk.gov.moj.cp.ai.index.IndexConstants.ID;
+import static uk.gov.moj.cp.ai.util.StringUtil.escapeODataStringLiteral;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A contiguous slice of the key space — {@code [lower, upper)}, where a {@code null} bound is unbounded —
+ * with an optional resume cursor. Owns the partitioning of the (UUID) key space into shards and the OData
+ * range/keyset filter construction for a page.
+ */
+record Shard(String lower, String upper, String startCursor) {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Shard.class);
+
+    /** Ordered hex prefixes of a v4 UUID key — the leading nibble is uniform, giving 16 even shards. */
+    private static final String HEX = "0123456789abcdef";
+
+    /**
+     * Partitions the key space. One worker → a single full-range shard seeded with the resume cursor.
+     * More workers → 16 shards by the leading hex character of the UUID key, each starting fresh
+     * ({@code startAfterId} is ignored — per-shard cursors make a single resume id meaningless, and
+     * re-running is safe because uploads are idempotent upserts).
+     */
+    static List<Shard> plan(final int workers, final String startAfterId) {
+        if (workers <= 1) {
+            return List.of(new Shard(null, null, startAfterId));
+        }
+        if (startAfterId != null && !startAfterId.isEmpty()) {
+            LOGGER.warn("startAfterId is ignored when workers > 1; shards restart from their range "
+                    + "(re-run is safe — uploads are idempotent upserts).");
+        }
+        final List<Shard> shards = new ArrayList<>(HEX.length());
+        for (int i = 0; i < HEX.length(); i++) {
+            final String lower = String.valueOf(HEX.charAt(i));
+            final String upper = i < HEX.length() - 1 ? String.valueOf(HEX.charAt(i + 1)) : "g";
+            shards.add(new Shard(lower, upper, null));
+        }
+        return shards;
+    }
+
+    /** Short label for logging: the lower bound, or "all" for the unbounded single shard. */
+    String label() {
+        return lower == null ? "all" : lower;
+    }
+
+    /** Composes the OData page filter: this shard's bounds (if any) AND the keyset cursor (if any). */
+    String pageFilter(final String lastId) {
+        final List<String> parts = new ArrayList<>(3);
+        if (lower != null) {
+            parts.add(format("%s ge '%s'", ID, escapeODataStringLiteral(lower)));
+        }
+        if (upper != null) {
+            parts.add(format("%s lt '%s'", ID, escapeODataStringLiteral(upper)));
+        }
+        final String cursor = keysetFilter(lastId);
+        if (cursor != null) {
+            parts.add(cursor);
+        }
+        return parts.isEmpty() ? null : String.join(" and ", parts);
+    }
+
+    /** The keyset cursor predicate ({@code id gt '<lastId>'}), or {@code null} for the first page. */
+    static String keysetFilter(final String lastId) {
+        if (lastId == null || lastId.isEmpty()) {
+            return null;
+        }
+        return format("%s gt '%s'", ID, escapeODataStringLiteral(lastId));
+    }
+}

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/SyncUploader.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/SyncUploader.java
@@ -1,0 +1,87 @@
+package uk.gov.moj.cp.migration;
+
+import static uk.gov.moj.cp.ai.index.IndexConstants.CHUNK;
+import static uk.gov.moj.cp.ai.index.IndexConstants.CHUNK_INDEX;
+import static uk.gov.moj.cp.ai.index.IndexConstants.CHUNK_VECTOR;
+import static uk.gov.moj.cp.ai.index.IndexConstants.CUSTOM_METADATA;
+import static uk.gov.moj.cp.ai.index.IndexConstants.DOCUMENT_FILE_NAME;
+import static uk.gov.moj.cp.ai.index.IndexConstants.DOCUMENT_FILE_URL;
+import static uk.gov.moj.cp.ai.index.IndexConstants.DOCUMENT_ID;
+import static uk.gov.moj.cp.ai.index.IndexConstants.ID;
+import static uk.gov.moj.cp.ai.index.IndexConstants.PAGE_NUMBER;
+
+import uk.gov.moj.cp.ai.model.ChunkedEntry;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.azure.core.util.Context;
+import com.azure.search.documents.SearchClient;
+import com.azure.search.documents.SearchDocument;
+import com.azure.search.documents.models.IndexDocumentsOptions;
+import com.azure.search.documents.models.IndexingResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Synchronous upload path: uploads each page via the target {@link SearchClient} and blocks until it is
+ * indexed before the worker reads the next page. This bounds in-flight memory to {@code workers × pageSize}
+ * regardless of heap size (no producer-side backlog), which is what makes the migration safe on a
+ * memory-constrained host. Per-document failures are counted (non-fatal), matching the async path; a hard
+ * request failure (after SDK retries) propagates and aborts the run via the watchdog.
+ */
+final class SyncUploader implements DocumentUploader {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SyncUploader.class);
+
+    private final SearchClient target;
+    private final AtomicLong succeeded;
+    private final AtomicLong failed;
+
+    SyncUploader(final SearchClient target, final AtomicLong succeeded, final AtomicLong failed) {
+        this.target = target;
+        this.succeeded = succeeded;
+        this.failed = failed;
+    }
+
+    @Override
+    public void upload(final List<ChunkedEntry> docs) {
+        final List<SearchDocument> batch = new ArrayList<>(docs.size());
+        for (final ChunkedEntry entry : docs) {
+            batch.add(toSearchDocument(entry));
+        }
+        // setThrowOnAnyError(false): per-doc failures are reported in the results (counted, non-fatal) rather
+        // than throwing, mirroring the buffered sender's onActionError handling.
+        final var result = target.uploadDocumentsWithResponse(
+                batch, new IndexDocumentsOptions().setThrowOnAnyError(false), Context.NONE).getValue();
+        for (final IndexingResult indexed : result.getResults()) {
+            if (indexed.isSucceeded()) {
+                succeeded.incrementAndGet();
+            } else {
+                failed.incrementAndGet();
+                LOGGER.error("Indexing failed for id={} (status {}): {}",
+                        indexed.getKey(), indexed.getStatusCode(), indexed.getErrorMessage());
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        // Nothing buffered — each page was uploaded synchronously.
+    }
+
+    private static SearchDocument toSearchDocument(final ChunkedEntry entry) {
+        final SearchDocument document = new SearchDocument();
+        document.put(ID, entry.id());
+        document.put(CHUNK, entry.chunk());
+        document.put(CHUNK_VECTOR, entry.chunkVector());
+        document.put(DOCUMENT_FILE_NAME, entry.documentFileName());
+        document.put(DOCUMENT_ID, entry.documentId());
+        document.put(PAGE_NUMBER, entry.pageNumber());
+        document.put(CHUNK_INDEX, entry.chunkIndex());
+        document.put(DOCUMENT_FILE_URL, entry.documentFileUrl());
+        document.put(CUSTOM_METADATA, entry.customMetadata());
+        return document;
+    }
+}

--- a/ai-document-migration-tool/src/main/resources/log4j2.xml
+++ b/ai-document-migration-tool/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/BufferedSenderUploaderTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/BufferedSenderUploaderTest.java
@@ -1,0 +1,28 @@
+package uk.gov.moj.cp.migration;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import uk.gov.moj.cp.ai.model.ChunkedEntry;
+
+import java.util.List;
+
+import com.azure.search.documents.SearchIndexingBufferedSender;
+import org.junit.jupiter.api.Test;
+
+class BufferedSenderUploaderTest {
+
+    @Test
+    void uploadDelegatesToTheSenderAndCloseFlushesIt() {
+        @SuppressWarnings("unchecked")
+        final SearchIndexingBufferedSender<ChunkedEntry> sender = mock(SearchIndexingBufferedSender.class);
+        final BufferedSenderUploader uploader = new BufferedSenderUploader(sender);
+        final List<ChunkedEntry> docs = List.of(ChunkedEntry.builder().id("x").build());
+
+        uploader.upload(docs);
+        uploader.close();
+
+        verify(sender).addUploadActions(docs);
+        verify(sender).close();
+    }
+}

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/IndexCopierTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/IndexCopierTest.java
@@ -1,13 +1,17 @@
 package uk.gov.moj.cp.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import uk.gov.moj.cp.ai.model.ChunkedEntry;
 
@@ -16,6 +20,8 @@ import java.util.List;
 
 import com.azure.search.documents.SearchClient;
 import com.azure.search.documents.SearchIndexingBufferedSender;
+import com.azure.search.documents.models.SearchResult;
+import com.azure.search.documents.util.SearchPagedIterable;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
@@ -104,6 +110,51 @@ class IndexCopierTest {
 
         assertThat(submitted).isZero();
         verifyNoInteractions(sender);
+    }
+
+    @Test
+    void readPageAppliesTheShardFilterAndMapsResultsToChunkedEntries() {
+        final SearchClient source = mock(SearchClient.class);
+        final SearchResult r1 = mock(SearchResult.class);
+        final SearchResult r2 = mock(SearchResult.class);
+        final ChunkedEntry c1 = chunk("id-a");
+        final ChunkedEntry c2 = chunk("id-b");
+        when(r1.getDocument(ChunkedEntry.class)).thenReturn(c1);
+        when(r2.getDocument(ChunkedEntry.class)).thenReturn(c2);
+        final SearchPagedIterable results = mock(SearchPagedIterable.class);
+        when(results.iterator()).thenReturn(List.of(r1, r2).iterator());
+        when(source.search(any(), any(), any())).thenReturn(results);
+
+        final List<ChunkedEntry> page =
+                new IndexCopier(source, mockSender(), 500, 1, 0).readPage(new Shard("a", "b", null), "a5");
+
+        assertThat(page).containsExactly(c1, c2);
+        verify(source).search(eq("*"), any(), any()); // shard-bounded keyset query issued
+    }
+
+    @Test
+    void copyAllDocumentsAbortsAndCancelsWorkersWhenAShardFails() {
+        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), mockSender(), 2, 1, 0));
+        doThrow(new RuntimeException("read boom")).when(copier).readPage(any(), any());
+
+        assertThatThrownBy(() -> copier.copyAllDocuments(null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("worker failed");
+    }
+
+    @Test
+    void copyAllDocumentsCountsAlreadyProcessedDocsWhenResumingASingleWorkerRun() {
+        final SearchClient source = mock(SearchClient.class);
+        final SearchPagedIterable countResult = mock(SearchPagedIterable.class);
+        when(countResult.getTotalCount()).thenReturn(42L);
+        when(source.search(any(), any(), any())).thenReturn(countResult);
+        final IndexCopier copier = spy(new IndexCopier(source, mockSender(), 2, 1, 0));
+        doReturn(List.of()).when(copier).readPage(any(), any()); // nothing left to copy from the cursor
+
+        final long submitted = copier.copyAllDocuments("cursor-x");
+
+        assertThat(submitted).isZero();
+        verify(source).search(any(), any(), any()); // resume count query executed (countProcessedBefore)
     }
 
     @SuppressWarnings("unchecked")

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/IndexCopierTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/IndexCopierTest.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.List;
 
 import com.azure.search.documents.SearchClient;
-import com.azure.search.documents.SearchIndexingBufferedSender;
 import com.azure.search.documents.models.SearchResult;
 import com.azure.search.documents.util.SearchPagedIterable;
 import org.junit.jupiter.api.Test;
@@ -42,9 +41,9 @@ class IndexCopierTest {
     }
 
     @Test
-    void copyAllDocumentsStreamsEachPageToSenderAndAdvancesCursorUntilPartialPage() {
-        final SearchIndexingBufferedSender<ChunkedEntry> sender = mockSender();
-        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), sender, 2, 1, 0));
+    void copyAllDocumentsUploadsEachPageAndAdvancesCursorUntilPartialPage() {
+        final DocumentUploader uploader = mock(DocumentUploader.class);
+        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), uploader, 2, 1, 0));
 
         final List<ChunkedEntry> page1 = List.of(chunk("id-1"), chunk("id-2")); // full page -> continue
         final List<ChunkedEntry> page2 = List.of(chunk("id-3"));                // partial page -> stop
@@ -56,18 +55,18 @@ class IndexCopierTest {
 
         // Cursor: first page starts at null, second resumes after the last id of page 1.
         final ArgumentCaptor<String> cursor = ArgumentCaptor.forClass(String.class);
-        final InOrder order = inOrder(copier, sender);
+        final InOrder order = inOrder(copier, uploader);
         order.verify(copier).readPage(any(), cursor.capture());
-        order.verify(sender).addUploadActions(page1); // plain (async, non-fatal) flush
+        order.verify(uploader).upload(page1);
         order.verify(copier).readPage(any(), cursor.capture());
-        order.verify(sender).addUploadActions(page2);
+        order.verify(uploader).upload(page2);
         assertThat(cursor.getAllValues()).containsExactly(null, "id-2");
     }
 
     @Test
     void copyAllDocumentsStopsAtTheMaxRecordsCapAndTrimsTheLastPage() {
-        final SearchIndexingBufferedSender<ChunkedEntry> sender = mockSender();
-        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), sender, 2, 1, 3));
+        final DocumentUploader uploader = mock(DocumentUploader.class);
+        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), uploader, 2, 1, 3));
 
         final ChunkedEntry c1 = chunk("id-1");
         final ChunkedEntry c2 = chunk("id-2");
@@ -78,15 +77,15 @@ class IndexCopierTest {
         final long submitted = copier.copyAllDocuments(null);
 
         assertThat(submitted).isEqualTo(3); // capped at maxRecords=3
-        verify(sender).addUploadActions(List.of(c1, c2)); // first full page
-        verify(sender).addUploadActions(List.of(c3));     // second page trimmed to the remaining budget (1)
+        verify(uploader).upload(List.of(c1, c2)); // first full page
+        verify(uploader).upload(List.of(c3));     // second page trimmed to the remaining budget (1)
     }
 
     @Test
-    void copyAllDocumentsSkipsChunksWithMissingOrWrongSizeVectorBeforeSubmitting() {
-        final SearchIndexingBufferedSender<ChunkedEntry> sender = mockSender();
+    void copyAllDocumentsSkipsChunksWithMissingOrWrongSizeVectorBeforeUploading() {
+        final DocumentUploader uploader = mock(DocumentUploader.class);
         // pageSize (5) > page (3) so the single page is "partial" and the read loop terminates after it.
-        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), sender, 5, 1, 0));
+        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), uploader, 5, 1, 0));
 
         final ChunkedEntry valid = chunk("id-1");                              // 3072-dim vector
         final ChunkedEntry wrongSize = chunkWithVector("id-2", List.of(0.0f)); // too short
@@ -96,20 +95,20 @@ class IndexCopierTest {
         final long submitted = copier.copyAllDocuments(null);
 
         assertThat(submitted).isEqualTo(1);
-        verify(sender).addUploadActions(List.of(valid)); // only the valid chunk is streamed
+        verify(uploader).upload(List.of(valid)); // only the valid chunk is uploaded
     }
 
     @Test
-    void copyAllDocumentsSubmitsNothingWhenSourceIsEmpty() {
-        final SearchIndexingBufferedSender<ChunkedEntry> sender = mockSender();
-        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), sender, 2, 1, 0));
+    void copyAllDocumentsUploadsNothingWhenSourceIsEmpty() {
+        final DocumentUploader uploader = mock(DocumentUploader.class);
+        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), uploader, 2, 1, 0));
 
         doReturn(List.of()).when(copier).readPage(any(), any());
 
         final long submitted = copier.copyAllDocuments(null);
 
         assertThat(submitted).isZero();
-        verifyNoInteractions(sender);
+        verifyNoInteractions(uploader);
     }
 
     @Test
@@ -126,7 +125,7 @@ class IndexCopierTest {
         when(source.search(any(), any(), any())).thenReturn(results);
 
         final List<ChunkedEntry> page =
-                new IndexCopier(source, mockSender(), 500, 1, 0).readPage(new Shard("a", "b", null), "a5");
+                new IndexCopier(source, mock(DocumentUploader.class), 500, 1, 0).readPage(new Shard("a", "b", null), "a5");
 
         assertThat(page).containsExactly(c1, c2);
         verify(source).search(eq("*"), any(), any()); // shard-bounded keyset query issued
@@ -134,7 +133,7 @@ class IndexCopierTest {
 
     @Test
     void copyAllDocumentsAbortsAndCancelsWorkersWhenAShardFails() {
-        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), mockSender(), 2, 1, 0));
+        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), mock(DocumentUploader.class), 2, 1, 0));
         doThrow(new RuntimeException("read boom")).when(copier).readPage(any(), any());
 
         assertThatThrownBy(() -> copier.copyAllDocuments(null))
@@ -148,18 +147,13 @@ class IndexCopierTest {
         final SearchPagedIterable countResult = mock(SearchPagedIterable.class);
         when(countResult.getTotalCount()).thenReturn(42L);
         when(source.search(any(), any(), any())).thenReturn(countResult);
-        final IndexCopier copier = spy(new IndexCopier(source, mockSender(), 2, 1, 0));
+        final IndexCopier copier = spy(new IndexCopier(source, mock(DocumentUploader.class), 2, 1, 0));
         doReturn(List.of()).when(copier).readPage(any(), any()); // nothing left to copy from the cursor
 
         final long submitted = copier.copyAllDocuments("cursor-x");
 
         assertThat(submitted).isZero();
         verify(source).search(any(), any(), any()); // resume count query executed (countProcessedBefore)
-    }
-
-    @SuppressWarnings("unchecked")
-    private static SearchIndexingBufferedSender<ChunkedEntry> mockSender() {
-        return mock(SearchIndexingBufferedSender.class);
     }
 
     private static ChunkedEntry chunk(final String id) {

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/IndexCopierTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/IndexCopierTest.java
@@ -1,0 +1,121 @@
+package uk.gov.moj.cp.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import uk.gov.moj.cp.ai.model.ChunkedEntry;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.azure.search.documents.SearchClient;
+import com.azure.search.documents.SearchIndexingBufferedSender;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+
+class IndexCopierTest {
+
+    @Test
+    void formatEtaReturnsUnknownBeforeAnyProgressIsMeasurable() {
+        assertThat(IndexCopier.formatEta(0, 100, 1_000_000_000L)).isEqualTo("unknown");
+        assertThat(IndexCopier.formatEta(100, 100, 0)).isEqualTo("unknown");
+    }
+
+    @Test
+    void formatEtaProjectsThisRunThroughputOverRemainingRecords() {
+        assertThat(IndexCopier.formatEta(100, 100, 100_000_000_000L)).isEqualTo("00:01:40");
+        assertThat(IndexCopier.formatEta(1, 7200, 1_000_000_000L)).isEqualTo("02:00:00");
+        assertThat(IndexCopier.formatEta(500, 0, 5_000_000_000L)).isEqualTo("00:00:00");
+    }
+
+    @Test
+    void copyAllDocumentsStreamsEachPageToSenderAndAdvancesCursorUntilPartialPage() {
+        final SearchIndexingBufferedSender<ChunkedEntry> sender = mockSender();
+        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), sender, 2, 1, 0));
+
+        final List<ChunkedEntry> page1 = List.of(chunk("id-1"), chunk("id-2")); // full page -> continue
+        final List<ChunkedEntry> page2 = List.of(chunk("id-3"));                // partial page -> stop
+        doReturn(page1).doReturn(page2).when(copier).readPage(any(), any());
+
+        final long submitted = copier.copyAllDocuments(null);
+
+        assertThat(submitted).isEqualTo(3);
+
+        // Cursor: first page starts at null, second resumes after the last id of page 1.
+        final ArgumentCaptor<String> cursor = ArgumentCaptor.forClass(String.class);
+        final InOrder order = inOrder(copier, sender);
+        order.verify(copier).readPage(any(), cursor.capture());
+        order.verify(sender).addUploadActions(page1); // plain (async, non-fatal) flush
+        order.verify(copier).readPage(any(), cursor.capture());
+        order.verify(sender).addUploadActions(page2);
+        assertThat(cursor.getAllValues()).containsExactly(null, "id-2");
+    }
+
+    @Test
+    void copyAllDocumentsStopsAtTheMaxRecordsCapAndTrimsTheLastPage() {
+        final SearchIndexingBufferedSender<ChunkedEntry> sender = mockSender();
+        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), sender, 2, 1, 3));
+
+        final ChunkedEntry c1 = chunk("id-1");
+        final ChunkedEntry c2 = chunk("id-2");
+        final ChunkedEntry c3 = chunk("id-3");
+        final ChunkedEntry c4 = chunk("id-4");
+        doReturn(List.of(c1, c2)).doReturn(List.of(c3, c4)).when(copier).readPage(any(), any());
+
+        final long submitted = copier.copyAllDocuments(null);
+
+        assertThat(submitted).isEqualTo(3); // capped at maxRecords=3
+        verify(sender).addUploadActions(List.of(c1, c2)); // first full page
+        verify(sender).addUploadActions(List.of(c3));     // second page trimmed to the remaining budget (1)
+    }
+
+    @Test
+    void copyAllDocumentsSkipsChunksWithMissingOrWrongSizeVectorBeforeSubmitting() {
+        final SearchIndexingBufferedSender<ChunkedEntry> sender = mockSender();
+        // pageSize (5) > page (3) so the single page is "partial" and the read loop terminates after it.
+        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), sender, 5, 1, 0));
+
+        final ChunkedEntry valid = chunk("id-1");                              // 3072-dim vector
+        final ChunkedEntry wrongSize = chunkWithVector("id-2", List.of(0.0f)); // too short
+        final ChunkedEntry nullVector = chunkWithVector("id-3", null);         // missing
+        doReturn(List.of(valid, wrongSize, nullVector)).when(copier).readPage(any(), any());
+
+        final long submitted = copier.copyAllDocuments(null);
+
+        assertThat(submitted).isEqualTo(1);
+        verify(sender).addUploadActions(List.of(valid)); // only the valid chunk is streamed
+    }
+
+    @Test
+    void copyAllDocumentsSubmitsNothingWhenSourceIsEmpty() {
+        final SearchIndexingBufferedSender<ChunkedEntry> sender = mockSender();
+        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), sender, 2, 1, 0));
+
+        doReturn(List.of()).when(copier).readPage(any(), any());
+
+        final long submitted = copier.copyAllDocuments(null);
+
+        assertThat(submitted).isZero();
+        verifyNoInteractions(sender);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static SearchIndexingBufferedSender<ChunkedEntry> mockSender() {
+        return mock(SearchIndexingBufferedSender.class);
+    }
+
+    private static ChunkedEntry chunk(final String id) {
+        return chunkWithVector(id, Collections.nCopies(IndexCopier.VECTOR_DIMENSIONS, 0.0f));
+    }
+
+    private static ChunkedEntry chunkWithVector(final String id, final List<Float> vector) {
+        return ChunkedEntry.builder().id(id).chunkVector(vector).build();
+    }
+}

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/IndexMigrationToolTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/IndexMigrationToolTest.java
@@ -1,0 +1,113 @@
+package uk.gov.moj.cp.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import uk.gov.moj.cp.ai.client.AISearchClientFactory;
+import uk.gov.moj.cp.ai.model.ChunkedEntry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.azure.search.documents.SearchClient;
+import com.azure.search.documents.SearchIndexingBufferedSender;
+import com.azure.search.documents.indexes.SearchIndexClient;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+/**
+ * Unit tests for the {@code main} wiring — argument parsing and which collaborators are invoked — with all
+ * Azure-touching collaborators (the static {@link SearchIndexAdmin}/{@link AISearchClientFactory} factories
+ * and the constructed {@link IndexCopier}) mocked. No live service is contacted.
+ */
+class IndexMigrationToolTest {
+
+    private static final String ENDPOINT = "https://svc.search.windows.net";
+
+    @Test
+    void mainRejectsTooFewArguments() {
+        assertThatThrownBy(() -> IndexMigrationTool.main(new String[]{"a", "b", "c", "d"}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Usage:");
+    }
+
+    @Test
+    void fullCopyRunWiresClientsRunsTheCopyThenVerifiesCountsAndPrintsCutover() throws Exception {
+        final SearchIndexClient indexClient = mock(SearchIndexClient.class);
+        final SearchClient sourceClient = mock(SearchClient.class);
+        final SearchIndexingBufferedSender<ChunkedEntry> sender = senderMock();
+        final List<List<Object>> copierCtorArgs = new ArrayList<>();
+
+        try (MockedStatic<SearchIndexAdmin> admin = mockStatic(SearchIndexAdmin.class);
+             MockedStatic<AISearchClientFactory> factory = mockStatic(AISearchClientFactory.class);
+             MockedConstruction<IndexCopier> copier = mockConstruction(IndexCopier.class, (m, ctx) -> {
+                 copierCtorArgs.add(new ArrayList<>(ctx.arguments()));
+                 when(m.copyAllDocuments(any())).thenReturn(1234L);
+             })) {
+
+            admin.when(() -> SearchIndexAdmin.indexClient(any())).thenReturn(indexClient);
+            admin.when(() -> SearchIndexAdmin.bufferedSender(any(), any(), anyInt(), any(), any())).thenReturn(sender);
+            factory.when(() -> AISearchClientFactory.getInstance(any(), any())).thenReturn(sourceClient);
+
+            IndexMigrationTool.main(new String[]{ENDPOINT, "src-index", "tgt-index", "the-alias", "/schema.json"});
+
+            // Index created from the schema, source client resolved, copy run on a single constructed copier.
+            admin.verify(() -> SearchIndexAdmin.indexClient(ENDPOINT));
+            admin.verify(() -> SearchIndexAdmin.createTargetIndex(indexClient, "tgt-index", "/schema.json"));
+            factory.verify(() -> AISearchClientFactory.getInstance(ENDPOINT, "src-index"));
+            assertThat(copier.constructed()).hasSize(1);
+            // Defaults applied: pageSize=500, workers=8, maxRecords=0; startAfterId=null.
+            assertThat(copierCtorArgs.get(0)).containsExactly(sourceClient, sender, 500, 8, 0L);
+            verify(copier.constructed().get(0)).copyAllDocuments(null);
+            verify(sender).close();
+            // Full copy -> verify counts and print the cutover command.
+            admin.verify(() -> SearchIndexAdmin.verifyCounts(indexClient, "src-index", "tgt-index", 0L));
+            admin.verify(() -> SearchIndexAdmin.logCutoverCommand(ENDPOINT, "the-alias", "tgt-index"));
+        }
+    }
+
+    @Test
+    void sampleCopyRunParsesWorkersMaxRecordsAndCursorAndSkipsVerificationAndCutover() throws Exception {
+        final SearchClient sourceClient = mock(SearchClient.class);
+        final SearchIndexingBufferedSender<ChunkedEntry> sender = senderMock();
+        final List<List<Object>> copierCtorArgs = new ArrayList<>();
+
+        try (MockedStatic<SearchIndexAdmin> admin = mockStatic(SearchIndexAdmin.class);
+             MockedStatic<AISearchClientFactory> factory = mockStatic(AISearchClientFactory.class);
+             MockedConstruction<IndexCopier> copier = mockConstruction(IndexCopier.class, (m, ctx) -> {
+                 copierCtorArgs.add(new ArrayList<>(ctx.arguments()));
+                 when(m.copyAllDocuments(any())).thenReturn(20000L);
+             })) {
+
+            admin.when(() -> SearchIndexAdmin.indexClient(any())).thenReturn(mock(SearchIndexClient.class));
+            admin.when(() -> SearchIndexAdmin.bufferedSender(any(), any(), anyInt(), any(), any())).thenReturn(sender);
+            factory.when(() -> AISearchClientFactory.getInstance(any(), any())).thenReturn(sourceClient);
+
+            IndexMigrationTool.main(new String[]{
+                    ENDPOINT, "src-index", "tgt-index", "the-alias", "/schema.json", "4", "20000", "cursor-9"});
+
+            // workers=4 and maxRecords=20000 parsed onto the copier; startAfterId="cursor-9" passed to the copy.
+            assertThat(copierCtorArgs.get(0)).containsExactly(sourceClient, sender, 500, 4, 20000L);
+            verify(copier.constructed().get(0)).copyAllDocuments("cursor-9");
+            verify(sender).close();
+            // Sample run -> NO count verification and NO cutover command.
+            admin.verify(() -> SearchIndexAdmin.verifyCounts(any(), any(), any(), anyLong()), never());
+            admin.verify(() -> SearchIndexAdmin.logCutoverCommand(any(), any(), any()), never());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static SearchIndexingBufferedSender<ChunkedEntry> senderMock() {
+        return mock(SearchIndexingBufferedSender.class);
+    }
+}

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/IndexMigrationToolTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/IndexMigrationToolTest.java
@@ -17,6 +17,7 @@ import uk.gov.moj.cp.ai.model.ChunkedEntry;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import com.azure.search.documents.SearchClient;
 import com.azure.search.documents.SearchIndexingBufferedSender;
@@ -66,8 +67,11 @@ class IndexMigrationToolTest {
             admin.verify(() -> SearchIndexAdmin.createTargetIndex(indexClient, "tgt-index", "/schema.json"));
             factory.verify(() -> AISearchClientFactory.getInstance(ENDPOINT, "src-index"));
             assertThat(copier.constructed()).hasSize(1);
-            // Defaults applied: pageSize=500, workers=8, maxRecords=0; startAfterId=null.
-            assertThat(copierCtorArgs.get(0)).containsExactly(sourceClient, sender, 500, 8, 0L);
+            // Defaults applied: pageSize=500, workers=8, maxRecords=0; startAfterId=null; default async uploader.
+            final List<Object> ctorArgs = copierCtorArgs.get(0);
+            assertThat(ctorArgs.get(0)).isSameAs(sourceClient);
+            assertThat(ctorArgs.get(1)).isInstanceOf(BufferedSenderUploader.class);
+            assertThat(ctorArgs.subList(2, 5)).containsExactly(IndexMigrationTool.DEFAULT_PAGE_SIZE, 8, 0L);
             verify(copier.constructed().get(0)).copyAllDocuments(null);
             verify(sender).close();
             // Full copy -> verify counts and print the cutover command.
@@ -97,12 +101,31 @@ class IndexMigrationToolTest {
                     ENDPOINT, "src-index", "tgt-index", "the-alias", "/schema.json", "4", "20000", "cursor-9"});
 
             // workers=4 and maxRecords=20000 parsed onto the copier; startAfterId="cursor-9" passed to the copy.
-            assertThat(copierCtorArgs.get(0)).containsExactly(sourceClient, sender, 500, 4, 20000L);
+            final List<Object> ctorArgs = copierCtorArgs.get(0);
+            assertThat(ctorArgs.get(0)).isSameAs(sourceClient);
+            assertThat(ctorArgs.subList(2, 5)).containsExactly(IndexMigrationTool.DEFAULT_PAGE_SIZE, 4, 20000L);
             verify(copier.constructed().get(0)).copyAllDocuments("cursor-9");
             verify(sender).close();
             // Sample run -> NO count verification and NO cutover command.
             admin.verify(() -> SearchIndexAdmin.verifyCounts(any(), any(), any(), anyLong()), never());
             admin.verify(() -> SearchIndexAdmin.logCutoverCommand(any(), any(), any()), never());
+        }
+    }
+
+    @Test
+    void uploaderSelectsSyncForSyncModeAndAsyncOtherwise() {
+        try (MockedStatic<AISearchClientFactory> factory = mockStatic(AISearchClientFactory.class);
+             MockedStatic<SearchIndexAdmin> admin = mockStatic(SearchIndexAdmin.class)) {
+
+            factory.when(() -> AISearchClientFactory.getInstance(any(), any())).thenReturn(mock(SearchClient.class));
+            admin.when(() -> SearchIndexAdmin.bufferedSender(any(), any(), anyInt(), any(), any())).thenReturn(senderMock());
+
+            assertThat(IndexMigrationTool.uploader("sync", "e", "t", 250, new AtomicLong(), new AtomicLong()))
+                    .isInstanceOf(SyncUploader.class);
+            assertThat(IndexMigrationTool.uploader("ASYNC", "e", "t", 250, new AtomicLong(), new AtomicLong()))
+                    .isInstanceOf(BufferedSenderUploader.class);
+            assertThat(IndexMigrationTool.uploader(null, "e", "t", 250, new AtomicLong(), new AtomicLong()))
+                    .isInstanceOf(BufferedSenderUploader.class); // default
         }
     }
 

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/SearchIndexAdminTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/SearchIndexAdminTest.java
@@ -1,12 +1,18 @@
 package uk.gov.moj.cp.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import uk.gov.moj.cp.ai.model.ChunkedEntry;
+
+import java.util.concurrent.atomic.AtomicLong;
+
 import com.azure.search.documents.SearchClient;
+import com.azure.search.documents.SearchIndexingBufferedSender;
 import com.azure.search.documents.indexes.SearchIndexClient;
 import com.azure.search.documents.indexes.models.SearchIndex;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -63,6 +69,29 @@ class SearchIndexAdminTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("source=100")
                 .hasMessageContaining("target=99");
+    }
+
+    @Test
+    void logCutoverCommandRendersForEndpointsWithAndWithoutATrailingSlash() {
+        // Exercises both arms of the trailing-slash trim; output is a log line, so we just assert it runs.
+        assertThatCode(() -> {
+            SearchIndexAdmin.logCutoverCommand("https://svc.search.windows.net/", "the-alias", "target-v2");
+            SearchIndexAdmin.logCutoverCommand("https://svc.search.windows.net", "the-alias", "target-v2");
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void indexClientIsBuiltForTheEndpoint() {
+        assertThat(SearchIndexAdmin.indexClient("https://svc.search.windows.net")).isNotNull();
+    }
+
+    @Test
+    void bufferedSenderIsBuiltAndClosesCleanly() {
+        final SearchIndexingBufferedSender<ChunkedEntry> sender = SearchIndexAdmin.bufferedSender(
+                "https://svc.search.windows.net", "idx", 500, new AtomicLong(), new AtomicLong());
+
+        assertThat(sender).isNotNull();
+        sender.close(); // empty buffer -> no network; just tears down the auto-flush scheduler
     }
 
     private static SearchIndexClient indexClientWithCounts(final long sourceCount, final long targetCount) {

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/SearchIndexAdminTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/SearchIndexAdminTest.java
@@ -1,0 +1,78 @@
+package uk.gov.moj.cp.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.azure.search.documents.SearchClient;
+import com.azure.search.documents.indexes.SearchIndexClient;
+import com.azure.search.documents.indexes.models.SearchIndex;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class SearchIndexAdminTest {
+
+    private static final String V2_SCHEMA = "/vector-db-index-schema-v2.json";
+
+    @Test
+    void loadSchemaWithNameOverridesTheIndexNameAndPreservesEverythingElse() throws Exception {
+        final JsonNode root = new ObjectMapper()
+                .readTree(SearchIndexAdmin.loadSchemaWithName(V2_SCHEMA, "my-target-index"));
+
+        assertThat(root.get("name").asText()).isEqualTo("my-target-index"); // name overridden
+        assertThat(root.has("fields")).isTrue();                            // rest of the schema preserved
+        assertThat(root.has("vectorSearch")).isTrue();
+        assertThat(root.toString()).contains("chunkVector");
+    }
+
+    @Test
+    void loadSchemaWithNameThrowsWhenTheResourceIsMissing() {
+        assertThatThrownBy(() -> SearchIndexAdmin.loadSchemaWithName("/does-not-exist.json", "x"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not found");
+    }
+
+    @Test
+    void createTargetIndexParsesTheSchemaWithTheOverriddenNameAndCreatesIt() throws Exception {
+        final SearchIndexClient indexClient = mock(SearchIndexClient.class);
+
+        SearchIndexAdmin.createTargetIndex(indexClient, "ai-rag-service-index-test", V2_SCHEMA);
+
+        final ArgumentCaptor<SearchIndex> created = ArgumentCaptor.forClass(SearchIndex.class);
+        verify(indexClient).createOrUpdateIndex(created.capture());
+        // Confirms the real v2 schema parses via SearchIndex.fromJson and that the physical name is overridden.
+        assertThat(created.getValue().getName()).isEqualTo("ai-rag-service-index-test");
+        assertThat(created.getValue().getFields()).isNotEmpty();
+    }
+
+    @Test
+    void verifyCountsPassesWhenSourceAndTargetMatch() {
+        final SearchIndexClient indexClient = indexClientWithCounts(100L, 100L);
+        SearchIndexAdmin.verifyCounts(indexClient, "source", "target", 100L); // no exception
+    }
+
+    @Test
+    void verifyCountsThrowsOnMismatch() {
+        final SearchIndexClient indexClient = indexClientWithCounts(100L, 99L);
+
+        assertThatThrownBy(() -> SearchIndexAdmin.verifyCounts(indexClient, "source", "target", 99L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("source=100")
+                .hasMessageContaining("target=99");
+    }
+
+    private static SearchIndexClient indexClientWithCounts(final long sourceCount, final long targetCount) {
+        final SearchIndexClient indexClient = mock(SearchIndexClient.class);
+        final SearchClient source = mock(SearchClient.class);
+        final SearchClient target = mock(SearchClient.class);
+        when(indexClient.getSearchClient("source")).thenReturn(source);
+        when(indexClient.getSearchClient("target")).thenReturn(target);
+        when(source.getDocumentCount()).thenReturn(sourceCount);
+        when(target.getDocumentCount()).thenReturn(targetCount);
+        return indexClient;
+    }
+}

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/ShardTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/ShardTest.java
@@ -1,0 +1,59 @@
+package uk.gov.moj.cp.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class ShardTest {
+
+    @Test
+    void labelIsAllForTheUnboundedShardAndTheLowerBoundOtherwise() {
+        assertThat(new Shard(null, null, null).label()).isEqualTo("all");
+        assertThat(new Shard("a", "b", null).label()).isEqualTo("a");
+    }
+
+    @Test
+    void keysetFilterReturnsNullForTheFirstPage() {
+        assertThat(Shard.keysetFilter(null)).isNull();
+        assertThat(Shard.keysetFilter("")).isNull();
+    }
+
+    @Test
+    void keysetFilterOrdersByIdGreaterThanCursor() {
+        assertThat(Shard.keysetFilter("id-42")).isEqualTo("id gt 'id-42'");
+    }
+
+    @Test
+    void keysetFilterEscapesSingleQuotesToPreventFilterBreakage() {
+        assertThat(Shard.keysetFilter("O'Brien")).isEqualTo("id gt 'O''Brien'");
+    }
+
+    @Test
+    void pageFilterComposesShardBoundsWithCursor() {
+        assertThat(new Shard(null, null, null).pageFilter(null)).isNull();
+        assertThat(new Shard(null, null, null).pageFilter("x")).isEqualTo("id gt 'x'");
+        assertThat(new Shard("a", "b", null).pageFilter(null)).isEqualTo("id ge 'a' and id lt 'b'");
+        assertThat(new Shard("a", "b", null).pageFilter("a5"))
+                .isEqualTo("id ge 'a' and id lt 'b' and id gt 'a5'");
+    }
+
+    @Test
+    void planReturnsOneFullRangeShardCarryingTheCursorForASingleWorker() {
+        assertThat(Shard.plan(1, "cursor-1")).containsExactly(new Shard(null, null, "cursor-1"));
+    }
+
+    @Test
+    void planPartitionsTheUuidKeySpaceIntoSixteenContiguousHexShardsForMultipleWorkers() {
+        final List<Shard> shards = Shard.plan(8, null);
+
+        assertThat(shards).hasSize(16);
+        assertThat(shards.get(0)).isEqualTo(new Shard("0", "1", null));
+        assertThat(shards.get(9)).isEqualTo(new Shard("9", "a", null)); // hex boundary 9 -> a
+        assertThat(shards.get(15)).isEqualTo(new Shard("f", "g", null)); // last bucket closes at 'g'
+        for (int i = 0; i < shards.size() - 1; i++) {
+            assertThat(shards.get(i).upper()).isEqualTo(shards.get(i + 1).lower()); // contiguous, no gaps
+        }
+    }
+}

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/ShardTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/ShardTest.java
@@ -45,6 +45,14 @@ class ShardTest {
     }
 
     @Test
+    void planIgnoresAndWarnsAboutAResumeCursorWhenShardingAcrossMultipleWorkers() {
+        // workers > 1 + a non-empty cursor exercises the "startAfterId ignored" warn branch.
+        assertThat(Shard.plan(8, "some-cursor"))
+                .hasSize(16)
+                .allSatisfy(shard -> assertThat(shard.startCursor()).isNull());
+    }
+
+    @Test
     void planPartitionsTheUuidKeySpaceIntoSixteenContiguousHexShardsForMultipleWorkers() {
         final List<Shard> shards = Shard.plan(8, null);
 

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/SyncUploaderTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/SyncUploaderTest.java
@@ -1,0 +1,72 @@
+package uk.gov.moj.cp.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import uk.gov.moj.cp.ai.model.ChunkedEntry;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.azure.core.http.rest.Response;
+import com.azure.search.documents.SearchClient;
+import com.azure.search.documents.models.IndexDocumentsResult;
+import com.azure.search.documents.models.IndexingResult;
+import org.junit.jupiter.api.Test;
+
+class SyncUploaderTest {
+
+    @Test
+    void uploadCountsSucceededResults() {
+        final SearchClient target = mock(SearchClient.class);
+        final AtomicLong succeeded = new AtomicLong();
+        final AtomicLong failed = new AtomicLong();
+        stubUpload(target, result(true), result(true));
+
+        new SyncUploader(target, succeeded, failed).upload(List.of(chunk("id-1"), chunk("id-2")));
+
+        assertThat(succeeded.get()).isEqualTo(2);
+        assertThat(failed.get()).isZero();
+    }
+
+    @Test
+    void uploadCountsFailedResultsWithoutThrowing() {
+        final SearchClient target = mock(SearchClient.class);
+        final AtomicLong succeeded = new AtomicLong();
+        final AtomicLong failed = new AtomicLong();
+        stubUpload(target, result(true), result(false)); // one per-doc failure
+
+        assertThatCode(() -> new SyncUploader(target, succeeded, failed).upload(List.of(chunk("a"), chunk("b"))))
+                .doesNotThrowAnyException(); // per-doc errors are counted, not fatal
+
+        assertThat(succeeded.get()).isEqualTo(1);
+        assertThat(failed.get()).isEqualTo(1);
+    }
+
+    private static IndexingResult result(final boolean succeeded) {
+        final IndexingResult result = mock(IndexingResult.class);
+        when(result.isSucceeded()).thenReturn(succeeded);
+        if (!succeeded) {
+            when(result.getKey()).thenReturn("bad-id");
+            when(result.getStatusCode()).thenReturn(503);
+            when(result.getErrorMessage()).thenReturn("throttled");
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void stubUpload(final SearchClient target, final IndexingResult... results) {
+        final IndexDocumentsResult batchResult = mock(IndexDocumentsResult.class);
+        when(batchResult.getResults()).thenReturn(List.of(results));
+        final Response<IndexDocumentsResult> response = mock(Response.class);
+        when(response.getValue()).thenReturn(batchResult);
+        when(target.uploadDocumentsWithResponse(any(), any(), any())).thenReturn(response);
+    }
+
+    private static ChunkedEntry chunk(final String id) {
+        return ChunkedEntry.builder().id(id).build();
+    }
+}

--- a/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/client/config/ClientConfiguration.java
+++ b/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/client/config/ClientConfiguration.java
@@ -18,6 +18,9 @@ public class ClientConfiguration {
     private static final String DEFAULT_RESPONSE_TIMEOUT_IN_SECONDS = "180";
     private static final String DEFAULT_CONNECT_TIMEOUT_IN_SECONDS = "10";
     private static final String DEFAULT_READ_TIMEOUT_IN_SECONDS = "60";
+    // Defaults to 60s to match Netty's own default write timeout — backwards compatible. Lower it via
+    // HTTP_CLIENT_WRITE_TIMEOUT_IN_SECONDS to bound a stalled outbound upload (large-write) sooner.
+    private static final String DEFAULT_WRITE_TIMEOUT_IN_SECONDS = "60";
 
     private static final String DEFAULT_MAX_RETRIES = "3";
     private static final String DEFAULT_BASE_DELAY_IN_SECONDS = "1";
@@ -46,15 +49,18 @@ public class ClientConfiguration {
         final int responseTimeoutInSeconds = getRequiredEnvAsInteger("HTTP_CLIENT_RESPONSE_TIMEOUT_IN_SECONDS", DEFAULT_RESPONSE_TIMEOUT_IN_SECONDS);
         final int connectTimeoutInSeconds = getRequiredEnvAsInteger("HTTP_CLIENT_CONNECT_TIMEOUT_IN_SECONDS", DEFAULT_CONNECT_TIMEOUT_IN_SECONDS);
         final int readTimeoutInSeconds = getRequiredEnvAsInteger("HTTP_CLIENT_READ_TIMEOUT_IN_SECONDS", DEFAULT_READ_TIMEOUT_IN_SECONDS);
+        final int writeTimeoutInSeconds = getRequiredEnvAsInteger("HTTP_CLIENT_WRITE_TIMEOUT_IN_SECONDS", DEFAULT_WRITE_TIMEOUT_IN_SECONDS);
 
-        LOGGER.info("Creating Netty HTTP client with responseTimeoutInSeconds: {}, connectTimeoutInSeconds: {}, readTimeoutInSeconds: {}",
-                responseTimeoutInSeconds, connectTimeoutInSeconds, readTimeoutInSeconds);
+        LOGGER.info("Creating Netty HTTP client with responseTimeoutInSeconds: {}, connectTimeoutInSeconds: {}, "
+                        + "readTimeoutInSeconds: {}, writeTimeoutInSeconds: {}",
+                responseTimeoutInSeconds, connectTimeoutInSeconds, readTimeoutInSeconds, writeTimeoutInSeconds);
 
         // Configure the Netty HTTP client with custom timeouts.  Azure SDK uses this as default
         return new NettyAsyncHttpClientBuilder()
                 .responseTimeout(Duration.ofSeconds(responseTimeoutInSeconds))
                 .connectTimeout(Duration.ofSeconds(connectTimeoutInSeconds))
                 .readTimeout(Duration.ofSeconds(readTimeoutInSeconds))
+                .writeTimeout(Duration.ofSeconds(writeTimeoutInSeconds))
                 .build();
     }
 }

--- a/ai-document-shared-artefacts/src/main/resources/vector-db-index-schema-v2.json
+++ b/ai-document-shared-artefacts/src/main/resources/vector-db-index-schema-v2.json
@@ -1,0 +1,173 @@
+{
+  "name": "ai-rag-service-index",
+  "fields": [
+    {
+      "name": "id",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": true,
+      "facetable": false,
+      "key": true
+    },
+    {
+      "name": "chunk",
+      "type": "Edm.String",
+      "searchable": true,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "chunkVector",
+      "type": "Collection(Edm.Single)",
+      "searchable": true,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "dimensions": 3072,
+      "vectorSearchProfile": "default-vector-profile"
+    },
+    {
+      "name": "documentFileName",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false
+    },
+    {
+      "name": "documentId",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false
+    },
+    {
+      "name": "pageNumber",
+      "type": "Edm.Int32",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false
+    },
+    {
+      "name": "chunkIndex",
+      "type": "Edm.Int32",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false
+    },
+    {
+      "name": "documentFileUrl",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false
+    },
+    {
+      "name": "customMetadata",
+      "type": "Collection(Edm.ComplexType)",
+      "fields": [
+        {
+          "name": "key",
+          "type": "Edm.String",
+          "searchable": false,
+          "filterable": true,
+          "retrievable": true,
+          "stored": true,
+          "sortable": false,
+          "facetable": false,
+          "key": false
+        },
+        {
+          "name": "value",
+          "type": "Edm.String",
+          "searchable": false,
+          "filterable": true,
+          "retrievable": true,
+          "stored": true,
+          "sortable": false,
+          "facetable": false,
+          "key": false
+        }
+      ]
+    }
+  ],
+  "scoringProfiles": [],
+  "suggesters": [],
+  "analyzers": [],
+  "normalizers": [],
+  "tokenizers": [],
+  "tokenFilters": [],
+  "charFilters": [],
+  "similarity": {
+    "@odata.type": "#Microsoft.Azure.Search.BM25Similarity"
+  },
+  "semantic": {
+    "configurations": [
+      {
+        "name": "default-semantic-config",
+        "flightingOptIn": false,
+        "rankingOrder": "BoostedRerankerScore",
+        "prioritizedFields": {
+          "prioritizedContentFields": [
+            {
+              "fieldName": "chunk"
+            }
+          ],
+          "prioritizedKeywordsFields": []
+        }
+      }
+    ]
+  },
+  "vectorSearch": {
+    "algorithms": [
+      {
+        "name": "hnsw-config",
+        "kind": "hnsw",
+        "hnswParameters": {
+          "metric": "cosine",
+          "m": 4,
+          "efConstruction": 400,
+          "efSearch": 500
+        }
+      }
+    ],
+    "profiles": [
+      {
+        "name": "default-vector-profile",
+        "algorithm": "hnsw-config"
+      }
+    ],
+    "vectorizers": [],
+    "compressions": []
+  }
+}

--- a/ai-document-shared-artefacts/src/test/java/uk/gov/moj/cp/ai/client/config/ClientConfigurationTest.java
+++ b/ai-document-shared-artefacts/src/test/java/uk/gov/moj/cp/ai/client/config/ClientConfigurationTest.java
@@ -56,6 +56,7 @@ class ClientConfigurationTest {
             mockedStatic.verify(() -> getRequiredEnvAsInteger("HTTP_CLIENT_RESPONSE_TIMEOUT_IN_SECONDS", "180"));
             mockedStatic.verify(() -> getRequiredEnvAsInteger("HTTP_CLIENT_CONNECT_TIMEOUT_IN_SECONDS", "10"));
             mockedStatic.verify(() -> getRequiredEnvAsInteger("HTTP_CLIENT_READ_TIMEOUT_IN_SECONDS", "60"));
+            mockedStatic.verify(() -> getRequiredEnvAsInteger("HTTP_CLIENT_WRITE_TIMEOUT_IN_SECONDS", "60"));
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <module>ai-document-answer-scoring-function</module>
         <module>ai-document-status-check-function</module>
         <module>ai-service-orchestration-test</module>
+        <module>ai-document-migration-tool</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
### What
Adds a new `ai-document-migration-tool` module (not deployed) and a v2 Azure AI Search index schema
(`vector-db-index-schema-v2.json`), plus a README documenting both.

### Why
The live index was created with attribute flags that don't match how it's queried (identifier/URL fields
`searchable`; every field `sortable`/`facetable` despite nothing sorting/faceting). Correcting these is
immutable-on-a-populated-index, so it needs a rebuild: new index + copy + alias swap.

### Changes
- **v2 schema:** only `chunk` stays `searchable`; unused `sortable`/`facetable` removed; `documentId` made
  `filterable`; `synonymMaps` removed from non-searchable fields. Document data and vector/semantic/similarity
  config are unchanged. (Per-field detail in the module README.)
- **Migration tool:** creates the v2 index from the schema, copies all docs via keyset pagination, verifies
  source/target counts, and prints the `az rest` alias-cutover command (the pinned SDK has no alias API).
  - **Parallel & fast:** with `workers > 1`, the UUID key space is split into 16 shards read concurrently.
  - **Resilient:** shared buffered sender (auto-batch, 16 MB split, 429/503 retry) so transient errors don't
    abort the run; a no-progress watchdog bounds genuine hangs instead of wedging.
  - **Safe sampling:** `maxRecords` caps the copy for validation; capped runs skip verification and the
    cutover command.
- Decomposed into `IndexMigrationTool` (entry point), `IndexCopier` (engine), `Shard` (key-space/filters),
  `SearchIndexAdmin` (index/client admin); registered the module in the root `pom.xml`.

### Testing
- `mvn -pl ai-document-migration-tool -am clean test` — green (18 unit tests across `ShardTest`,
  `IndexCopierTest`, `SearchIndexAdminTest`); shared-artefacts suite unaffected.
- Validated end-to-end against the `ste` search service with a 20,000-record sample run (cap honoured;
  transient `Connection reset` errors ridden through; watchdog confirmed to bound a tail hang).

### Notes for reviewers
- The tool is operational only — no deployed function or runtime behaviour changes in this PR.
- Throughput is network-bound; running in-region is the main speed/stability lever.