### PR TITLE
DD-42737 - Containerising data migration tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ lightning-jenkins.properties
 
 dev/
 .claude/
+
+**/*.env
+

--- a/ai-document-migration-tool/.dockerignore
+++ b/ai-document-migration-tool/.dockerignore
@@ -1,0 +1,13 @@
+# Build context is this module directory; the image only needs the prebuilt runnable artifacts
+# (target/app jar + target/lib). Exclude sources and intermediate build output to keep the context lean.
+src/
+README.md
+Dockerfile
+target/classes/
+target/test-classes/
+target/generated-sources/
+target/generated-test-sources/
+target/maven-status/
+target/maven-archiver/
+target/*.original
+.DS_Store

--- a/ai-document-migration-tool/Dockerfile
+++ b/ai-document-migration-tool/Dockerfile
@@ -1,0 +1,32 @@
+# Runtime-only image for the one-off index-migration tool.
+#
+# The jar + dependency lib/ are built ON THE HOST first (the Maven build resolves through the internal
+# Artifactory mirror configured in ~/.m2/settings.xml, which a clean in-image build / cloud build agent
+# cannot reach). This image just packages those prebuilt artifacts into a clean JRE.
+#
+# Build context is THIS module directory (so target/ is available):
+#   mvn -pl ai-document-migration-tool -am -DskipTests package
+#   docker build -f ai-document-migration-tool/Dockerfile -t ai-index-migration:1 ai-document-migration-tool
+#
+# The image is deliberately clean: no Azure CLI, no secrets, no mounts. Authentication is resolved at
+# run time by DefaultAzureCredential — locally via a service principal in the environment
+# (AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET), and in an Azure Container Apps Job via the
+# attached managed identity. The same image therefore runs unchanged in both places.
+
+FROM eclipse-temurin:21-jre AS runtime
+WORKDIR /app
+
+# Non-root runtime user (fixed high uid; not --system, whose uids must stay below 1000).
+RUN useradd --uid 10001 --create-home appuser
+
+# Thin application jar (its manifest carries Main-Class + a lib/-relative Class-Path) plus the
+# dependency jars. Keeping dependencies as separate jars preserves each one's META-INF/services, so
+# the Azure SDK's ServiceLoader-based HTTP client / credential discovery works without uber-jar merging.
+COPY target/lib /app/lib
+COPY target/ai-document-migration-tool-*.jar /app/app.jar
+
+USER appuser
+
+# Migration args are supplied at run/Job-start time:
+#   <endpoint> <sourceIndex> <targetIndex> <aliasName> <schemaResourcePath> [workers] [maxRecords] [startAfterId]
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-jar", "/app/app.jar"]

--- a/ai-document-migration-tool/README.md
+++ b/ai-document-migration-tool/README.md
@@ -131,6 +131,43 @@ with no application change. Re-runs are safe — uploads are idempotent upserts 
 
 ---
 
+## Running as a container
+
+For running in Azure (e.g. an in-region Container Apps Job) or any clean host, the module ships a
+`Dockerfile`. It is **runtime-only**: build the runnable artifacts on a host that can reach the Maven
+repositories, then package them into a lean `eclipse-temurin:21-jre` image (no Azure CLI, no secrets).
+
+The build produces a thin jar plus a `lib/` of dependency jars (via `maven-jar-plugin` +
+`maven-dependency-plugin`) rather than a shaded uber-jar — keeping each dependency separate preserves its
+`META-INF/services`, so the Azure SDK's `ServiceLoader`-based HTTP-client and credential discovery works
+with no service-file merging.
+
+```bash
+# 1. build artifacts on the host, then the image (build context = this module dir)
+mvn -pl ai-document-migration-tool -am -DskipTests package
+docker build -f ai-document-migration-tool/Dockerfile -t ai-index-migration:1 ai-document-migration-tool
+
+# 2. run — args are the same positional args as the mvn invocation above
+docker run --rm --env-file sp.env ai-index-migration:1 \
+  https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 \
+  ai-rag-service-index-alias /vector-db-index-schema-v2.json 8 20000
+```
+
+**Credentials.** The image carries none; `DefaultAzureCredential` resolves them at runtime, so the *same
+image* works everywhere:
+- **Locally** — supply a service principal via env vars (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`,
+  `AZURE_CLIENT_SECRET`), e.g. a git-ignored `sp.env` passed with `--env-file`. Use bare `KEY=value` lines
+  (Docker does **not** strip quotes/spaces). The SP needs the same two roles listed in
+  [Prerequisites](#prerequisites).
+- **In Azure** — attach a managed identity to the Job; the credential chain picks it up with no env vars.
+
+The image is network-clean but the search service may be private — if requests hang after auth succeeds,
+it's DNS, not credentials. Probe with
+`docker run --rm --entrypoint getent ai-index-migration:1 hosts <svc>.search.windows.net`; if it doesn't
+resolve, add `--dns`/`--add-host` (or run where the private DNS zone is reachable).
+
+---
+
 ## Upload modes & tuning
 
 The copy is network-bound; tune for **throughput** or **memory** depending on the host.

--- a/ai-document-migration-tool/pom.xml
+++ b/ai-document-migration-tool/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -11,10 +13,14 @@
     <artifactId>ai-document-migration-tool</artifactId>
     <packaging>jar</packaging>
     <name>AI Document Migration Tool</name>
-    <description>One-off, resumable index-to-index migration tool for rebuilding the Azure AI Search index with a new schema. Not deployed.</description>
+    <description>One-off, resumable index-to-index migration tool for rebuilding the Azure AI Search
+        index with a new schema. Not deployed.
+    </description>
 
     <properties>
         <exec.maven.plugin.version>3.1.0</exec.maven.plugin.version>
+        <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
+        <maven.dependency.plugin.version>3.7.0</maven.dependency.plugin.version>
         <migration.mainClass>uk.gov.moj.cp.migration.IndexMigrationTool</migration.mainClass>
     </properties>
 
@@ -50,6 +56,48 @@
                 <configuration>
                     <mainClass>${migration.mainClass}</mainClass>
                 </configuration>
+            </plugin>
+
+            <!-- Package a runnable thin jar + a lib/ directory of dependencies (rather than a shaded
+                 uber-jar). The module is run standalone in a container.  This layout deliberately
+                 keeps every dependency as its own jar, so each one retains its own META-INF/services
+                 entries — the Azure SDK discovers its Netty HTTP client, JSON serializer providers
+                 and DefaultAzureCredential token sources via ServiceLoader, and a flat classpath needs
+                 no service-file merging (which an uber-jar would). The jar-plugin writes Main-Class +
+                 a lib/-relative Class-Path into the manifest so `java -jar app.jar` just works;
+                 dependency-plugin populates lib/. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven.jar.plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>${migration.mainClass}</mainClass>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>lib/</classpathPrefix>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven.dependency.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-runtime-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                            <includeScope>runtime</includeScope>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
### What
Adds containerization for `ai-document-migration-tool` so it can be run as a standalone image (e.g. an
in-region Azure Container Apps Job) rather than only from a dev machine via Maven.

### Changes
- **`pom.xml`** — package a runnable **thin jar + `lib/`** (`maven-jar-plugin` writes `Main-Class` + a
  `lib/`-relative `Class-Path`; `maven-dependency-plugin` copies runtime deps). Deliberately **not** a
  shaded uber-jar: keeping each dependency as its own jar preserves its `META-INF/services`, so the Azure
  SDK's `ServiceLoader`-based HTTP-client/credential discovery works with no service-file merging.
- **`Dockerfile`** — runtime-only `eclipse-temurin:21-jre`, non-root, no Azure CLI/secrets. Built from
  host-produced artifacts (the Maven build resolves via the internal Artifactory mirror, which a clean
  in-image/cloud build can't reach).
- **`.dockerignore`** — module-level; ships only the runtime artifacts.
- **`README.md`** — new "Running as a container" section (build/run, credential model, private-DNS probe).

### Credentials
Image carries none. Local: SP via `AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET` (`--env-file`).
Azure: attached managed identity. Same image, no rebuild.

### How to build & run
```bash
mvn -pl ai-document-migration-tool -am -DskipTests package
docker build -f ai-document-migration-tool/Dockerfile -t ai-index-migration:1 ai-document-migration-tool
docker run --rm --env-file sp.env ai-index-migration:1 \
  https://<svc>.search.windows.net source-index target-index \
  index-alias /index-schema.json 8 20000
```

### Testing
- `mvn package` → thin jar (correct manifest) + dependency `lib/`.
- Container: no-args run → usage error; bogus-SP run → reaches AAD over Netty (auth error, not a
  `ClassNotFound`/"no HttpClient provider"), confirming the classpath/`ServiceLoader` wiring.
- No application/runtime logic changed — packaging only.