### PR TITLE
DD-42739: Add Table Storage table-to-table copy tool with partition-key override

### DIFF
--- a/ai-document-migration-tool/Dockerfile
+++ b/ai-document-migration-tool/Dockerfile
@@ -27,6 +27,9 @@ COPY target/ai-document-migration-tool-*.jar /app/app.jar
 
 USER appuser
 
-# Migration args are supplied at run/Job-start time:
-#   <endpoint> <sourceIndex> <targetIndex> <aliasName> <schemaResourcePath> [workers] [maxRecords] [startAfterId]
+# The entrypoint is the MigrationTool dispatcher (jar Main-Class = uk.gov.moj.cp.migration.MigrationTool).
+# It takes the tool name as its FIRST argument, then that tool's own args — there is no default tool.
+# Args are supplied at run/Job-start time, e.g.:
+#   index <endpoint> <sourceIndex> <targetIndex> <aliasName> <schemaResourcePath> [workers] [maxRecords] [startAfterId]
+#   table <sourceTable> <targetTable> [partitionKeyOverride] [maxRecords]
 ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-jar", "/app/app.jar"]

--- a/ai-document-migration-tool/README.md
+++ b/ai-document-migration-tool/README.md
@@ -1,13 +1,21 @@
 # ai-document-migration-tool
 
-A one-off, resumable **index-to-index migration tool** for rebuilding the Azure AI Search index behind
-the RAG service with a corrected schema, copying all existing data across with **no re-embedding**.
+A home for one-off, **not deployed** operational migration utilities run by hand. It currently holds two:
 
-This module is **not deployed** — it is an operational utility run by hand when the search index schema
-needs to change.
+- **Index-to-index copy** (`uk.gov.moj.cp.migration.index`) — rebuilds the Azure AI Search index behind the
+  RAG service with a corrected schema, copying all existing data across with **no re-embedding**. It is the
+  bulk of this README.
+- **Table-to-table copy** (`uk.gov.moj.cp.migration.table`) — copies an Azure Storage table into a new table,
+  optionally rewriting every row's partition key (the multi-tenant migration). See
+  [Table Storage table-to-table copy](#table-storage-table-to-table-copy-multi-tenant-migration).
 
-> The specific schema changes this migration applies (and why) are documented separately in
-> **[SCHEMA_CHANGES.md](SCHEMA_CHANGES.md)**. This README focuses on how the tool works and how to run it.
+Both run through a single entry point (`uk.gov.moj.cp.migration.MigrationTool`) that takes the **tool name as
+its first argument** (`index` or `table`), followed by that tool's own arguments. There is **no default tool** —
+you always name the one you mean, so a bulk migration can never be triggered implicitly. Running it with no
+arguments (or `--help`) prints the usage for both.
+
+> The specific schema changes the index migration applies (and why) are documented separately in
+> **[SCHEMA_CHANGES.md](SCHEMA_CHANGES.md)**. This README focuses on how the tools work and how to run them.
 
 ---
 
@@ -69,29 +77,33 @@ How it applies the schema:
 
 ### Command
 
+The `index` subcommand selects this tool; everything after it is the index tool's own arguments.
+
 ```bash
 mvn -pl ai-document-migration-tool exec:java \
-  -Dexec.args="<endpoint> <sourceIndex> <targetIndex> <aliasName> <schemaResourcePath> [workers] [maxRecords] [startAfterId]"
+  -Dexec.args="index <endpoint> <sourceIndex> <targetIndex> <aliasName> <schemaResourcePath> [workers] [maxRecords] [startAfterId]"
 ```
 
 ```bash
 # Full copy, 8 concurrent shards (async, ample memory)
 mvn -pl ai-document-migration-tool exec:java \
-  -Dexec.args="https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 8"
+  -Dexec.args="index https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 8"
 
 # Sample copy of the first 20,000 records (validation) — no verification, no cutover command
 mvn -pl ai-document-migration-tool exec:java \
-  -Dexec.args="https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 8 20000"
+  -Dexec.args="index https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 8 20000"
 
 # Low-memory / constrained host: sync uploads, 4 workers, heap capped at 1 GB
 MAVEN_OPTS="-Xmx1g -XX:+UseG1GC" \
 MIGRATION_UPLOAD_MODE=sync \
 HTTP_CLIENT_WRITE_TIMEOUT_IN_SECONDS=15 HTTP_CLIENT_READ_TIMEOUT_IN_SECONDS=10 HTTP_CLIENT_RESPONSE_TIMEOUT_IN_SECONDS=30 \
 mvn -pl ai-document-migration-tool exec:java \
-  -Dexec.args="https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 4"
+  -Dexec.args="index https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 4"
 ```
 
 ### Arguments
+
+These are the `index` tool's arguments (they follow the `index` subcommand).
 
 | # | Argument | Required | Default | Description |
 |---|----------|----------|---------|-------------|
@@ -142,15 +154,20 @@ The build produces a thin jar plus a `lib/` of dependency jars (via `maven-jar-p
 `META-INF/services`, so the Azure SDK's `ServiceLoader`-based HTTP-client and credential discovery works
 with no service-file merging.
 
+The image `ENTRYPOINT` is `java -jar app.jar`, i.e. the `MigrationTool` dispatcher — so the container takes the
+**same arguments as the mvn invocation**: the tool name (`index` / `table`) first, then that tool's arguments.
+
 ```bash
 # 1. build artifacts on the host, then the image (build context = this module dir)
 mvn -pl ai-document-migration-tool -am -DskipTests package
-docker build -f ai-document-migration-tool/Dockerfile -t ai-index-migration:1 ai-document-migration-tool
+docker build -f ai-document-migration-tool/Dockerfile -t ai-rag-migration:1 ai-document-migration-tool
 
-# 2. run — args are the same positional args as the mvn invocation above
-docker run --rm --env-file sp.env ai-index-migration:1 \
-  https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 \
+# 2. run the index migration — note the leading "index" tool name
+docker run --rm --env-file sp.env ai-rag-migration:1 \
+  index https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 \
   ai-rag-service-index-alias /vector-db-index-schema-v2.json 8 20000
+
+# (the table tool is the same image with a leading "table" — see the table section)
 ```
 
 **Credentials.** The image carries none; `DefaultAzureCredential` resolves them at runtime, so the *same
@@ -163,7 +180,7 @@ image* works everywhere:
 
 The image is network-clean but the search service may be private — if requests hang after auth succeeds,
 it's DNS, not credentials. Probe with
-`docker run --rm --entrypoint getent ai-index-migration:1 hosts <svc>.search.windows.net`; if it doesn't
+`docker run --rm --entrypoint getent ai-rag-migration:1 hosts <svc>.search.windows.net`; if it doesn't
 resolve, add `--dns`/`--add-host` (or run where the private DNS zone is reachable).
 
 ---
@@ -215,7 +232,95 @@ Other knobs:
 
 ---
 
+## Table Storage table-to-table copy (multi-tenant migration)
+
+A separate, simpler tool (`uk.gov.moj.cp.migration.table.TableMigrationTool`) for **Azure Storage tables**. It
+copies every row from a source table into a new target table, optionally **rewriting each row's
+`PartitionKey`** to a fixed value while preserving the `RowKey` and all data columns.
+
+**Why it exists.** An Azure Table Storage `PartitionKey` is part of the entity's **immutable** primary key —
+there is no in-place update. To change it you must write a new entity under the new key. As the service goes
+multi-tenant, existing single-consumer rows (keyed today by `PartitionKey == RowKey == id`) need their
+`PartitionKey` set to a fixed consumer-id so each consumer becomes its own partition. This tool does that as a
+**copy into a new table**: it reads the source and upserts a transformed copy into the target, and **never
+mutates the source** — so a run is non-destructive (roll back by continuing to use the source), idempotent
+(re-runnable — upsert keyed by `(PartitionKey, RowKey)`), and safe to validate before cutover.
+
+It is deliberately **single-threaded**: unlike the index copier (which shards for ~340k vectors and the
+`$skip` 100k cap), these are small operational status tables and `listEntities()` transparently follows
+continuation tokens, so a sequential pass is the right altitude.
+
+### Run
+
+The `table` subcommand selects this tool; everything after it is the table tool's own arguments.
+
+```bash
+# copy every row, rewriting the partition key to a fixed consumer id
+mvn -pl ai-document-migration-tool exec:java \
+  -Dexec.args="table <sourceTable> <targetTable> <partitionKeyOverride>"
+
+# copy verbatim (keep each row's partition key), sample the first 100 rows
+#   pass "-" (or a blank) for the override slot so maxRecords stays positional
+mvn -pl ai-document-migration-tool exec:java \
+  -Dexec.args="table <sourceTable> <targetTable> - 100"
+```
+
+| Arg | Required | Meaning |
+|-----|----------|---------|
+| `sourceTable` | yes | Table to copy from (never written to). |
+| `targetTable` | yes | Table to copy into; created if absent. Must differ from `sourceTable`. |
+| `partitionKeyOverride` | no | Fixed `PartitionKey` for every copied row. Omit, or pass blank / `-`, to copy partition keys **verbatim**. |
+| `maxRecords` | no | Cap for a sample run; `0` (default) copies everything. |
+
+**Connection** is resolved from the environment by `TableClientFactory` (not from args) — the same config the
+deployed functions use:
+
+| Variable | Notes |
+|----------|-------|
+| `AI_RAG_SERVICE_TABLE_STORAGE_ENDPOINT` | Required for `MANAGED_IDENTITY`, e.g. `https://<account>.table.core.windows.net`. |
+
+In `MANAGED_IDENTITY` mode the identity needs the **Storage Table Data Contributor** role on the storage
+account. The `HTTP_CLIENT_*` / `AZURE_CLIENT_MAX_RETRIES` knobs in the table below apply here too.
+
+### Caveats
+
+- **Type fidelity.** Property values keep their EDM types on copy (`OffsetDateTime`, `Long`, `Double`,
+  `Boolean`, `UUID`, `byte[]`) because the raw objects are re-upserted as read. Decimal columns (e.g. the
+  groundedness score) are stored by the service as `Edm.Double` — there is no EDM decimal type — so they
+  round-trip as doubles. The copy performs no `toString`/re-typing.
+- **Override safety.** Under override every row lands in one partition, so the tool **fails loud** if two
+  source rows share a `RowKey` (which would otherwise silently overwrite). For the current `PartitionKey == RowKey`
+  tables this cannot happen; the guard protects any future table where they differ.
+- **Cutover sequencing.** This tool does **only the data copy**. The `consumerId` plumbing through the
+  application's read/write paths is a separate change; cut over together, and ensure the `partitionKeyOverride`
+  here exactly matches (casing/whitespace) the consumer-id the application will start using.
+
+### Running the table tool in a container
+
+The same [container image](#running-as-a-container) serves this tool — just pass the `table` subcommand and its
+arguments (the `ENTRYPOINT` is the `MigrationTool` dispatcher, so no entrypoint override is needed):
+
+```bash
+docker run --rm --env-file storage.env ai-rag-migration:1 \
+  table srcTable tgtTable my-consumer-id
+```
+
+In an Azure Container Apps Job, set the args to `["table", "srcTable", "tgtTable", "my-consumer-id"]`. Supply
+the storage connection env vars above; in `MANAGED_IDENTITY` mode the attached identity needs **Storage Table
+Data Contributor**.
+
+---
+
 ## Design / code layout
+
+The module has a single dispatcher entry point in the root `uk.gov.moj.cp.migration` package, over two domain
+sub-packages: `index` (the Search index→index tool) and `table` (the Storage table→table tool).
+
+| Class | Responsibility |
+|-------|----------------|
+| `MigrationTool` | Jar `Main-Class`: reads the tool name (`index` / `table`) as the first argument and forwards the rest to that tool; no default tool |
+
+**`index`**
 
 | Class | Responsibility |
 |-------|----------------|
@@ -226,6 +331,13 @@ Other knobs:
 | `DocumentUploader` | Upload abstraction — swap throughput for memory without touching the engine |
 | `BufferedSenderUploader` | Async path: streams into the shared buffered sender (default) |
 | `SyncUploader` | Sync path: per-page upload, bounding in-flight memory to `workers × pageSize` |
+
+**`table`**
+
+| Class | Responsibility |
+|-------|----------------|
+| `TableMigrationTool` | Entry point (`main`): parses args, resolves source/target clients via `TableClientFactory`, runs the copy |
+| `TableCopier` | The copy engine: ensures the target table, streams rows, applies the partition-key override, strips system properties, guards against RowKey collisions |
 
 ### Build & test
 

--- a/ai-document-migration-tool/pom.xml
+++ b/ai-document-migration-tool/pom.xml
@@ -19,7 +19,7 @@
         <exec.maven.plugin.version>3.1.0</exec.maven.plugin.version>
         <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
         <maven.dependency.plugin.version>3.7.0</maven.dependency.plugin.version>
-        <migration.mainClass>uk.gov.moj.cp.migration.IndexMigrationTool</migration.mainClass>
+        <migration.mainClass>uk.gov.moj.cp.migration.MigrationTool</migration.mainClass>
     </properties>
 
     <dependencies>
@@ -35,6 +35,13 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-search-documents</artifactId>
+        </dependency>
+
+        <!-- Table data-plane client (TableClient, TableEntity) for the table-to-table copy tool.
+             Version managed by azure-sdk-bom; mirrors the declaration in ai-document-shared-artefacts. -->
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-data-tables</artifactId>
         </dependency>
 
         <!-- Test (junit + mockito inherited project-wide; assertj is managed-only, so declare it here) -->

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/MigrationTool.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/MigrationTool.java
@@ -1,0 +1,65 @@
+package uk.gov.moj.cp.migration;
+
+import uk.gov.moj.cp.migration.index.IndexMigrationTool;
+import uk.gov.moj.cp.migration.table.TableMigrationTool;
+
+import java.util.Arrays;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Single entry point (jar {@code Main-Class}) for the migration utilities. The first argument selects the tool
+ * by name; the remaining arguments are forwarded to that tool verbatim.
+ *
+ * <p>There is deliberately <strong>no default tool</strong>: each tool performs a bulk, hard-to-undo copy, so
+ * the operator must name the one they mean rather than have the container fall back to one implicitly. An empty
+ * or unrecognised tool name prints the usage (listing both tools and their argument signatures) and fails.</p>
+ *
+ * <pre>
+ *   index  &lt;endpoint&gt; &lt;sourceIndex&gt; &lt;targetIndex&gt; &lt;aliasName&gt; &lt;schemaResourcePath&gt; [workers] [maxRecords] [startAfterId]
+ *   table  &lt;sourceTable&gt; &lt;targetTable&gt; [partitionKeyOverride] [maxRecords]
+ *
+ *   # via the packaged jar / container (ENTRYPOINT is "java -jar app.jar")
+ *   docker run --rm --env-file env ai-rag-migration:1 table srcTable tgtTable my-consumer-id
+ *
+ *   # via maven
+ *   mvn -pl ai-document-migration-tool exec:java -Dexec.args="table srcTable tgtTable my-consumer-id"
+ * </pre>
+ */
+public final class MigrationTool {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MigrationTool.class);
+
+    private static final String USAGE = """
+            Usage: <tool> <tool-args...>  (no default — name the tool explicitly)
+              index  <endpoint> <sourceIndex> <targetIndex> <aliasName> <schemaResourcePath> [workers] [maxRecords] [startAfterId]
+              table  <sourceTable> <targetTable> [partitionKeyOverride] [maxRecords]""";
+
+    private MigrationTool() {
+    }
+
+    public static void main(final String[] args) throws Exception {
+        if (args.length == 0 || isHelp(args[0])) {
+            if (args.length == 0) {
+                throw new IllegalArgumentException("No migration tool specified.\n" + USAGE);
+            }
+            LOGGER.info(USAGE);
+            return;
+        }
+
+        final String tool = args[0];
+        final String[] toolArgs = Arrays.copyOfRange(args, 1, args.length);
+        LOGGER.info("Running migration tool '{}'.", tool);
+
+        switch (tool) {
+            case "index" -> IndexMigrationTool.main(toolArgs);
+            case "table" -> TableMigrationTool.main(toolArgs);
+            default -> throw new IllegalArgumentException("Unknown migration tool '" + tool + "'.\n" + USAGE);
+        }
+    }
+
+    private static boolean isHelp(final String arg) {
+        return "help".equals(arg) || "-h".equals(arg) || "--help".equals(arg);
+    }
+}

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/BufferedSenderUploader.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/BufferedSenderUploader.java
@@ -1,4 +1,4 @@
-package uk.gov.moj.cp.migration;
+package uk.gov.moj.cp.migration.index;
 
 import uk.gov.moj.cp.ai.model.ChunkedEntry;
 

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/DocumentUploader.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/DocumentUploader.java
@@ -1,4 +1,4 @@
-package uk.gov.moj.cp.migration;
+package uk.gov.moj.cp.migration.index;
 
 import uk.gov.moj.cp.ai.model.ChunkedEntry;
 

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/IndexCopier.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/IndexCopier.java
@@ -1,4 +1,4 @@
-package uk.gov.moj.cp.migration;
+package uk.gov.moj.cp.migration.index;
 
 import static java.lang.String.format;
 import static uk.gov.moj.cp.ai.index.IndexConstants.ID;

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/IndexMigrationTool.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/IndexMigrationTool.java
@@ -1,4 +1,4 @@
-package uk.gov.moj.cp.migration;
+package uk.gov.moj.cp.migration.index;
 
 import static java.lang.String.format;
 

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/SearchIndexAdmin.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/SearchIndexAdmin.java
@@ -1,4 +1,4 @@
-package uk.gov.moj.cp.migration;
+package uk.gov.moj.cp.migration.index;
 
 import static java.lang.String.format;
 

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/Shard.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/Shard.java
@@ -1,4 +1,4 @@
-package uk.gov.moj.cp.migration;
+package uk.gov.moj.cp.migration.index;
 
 import static java.lang.String.format;
 import static uk.gov.moj.cp.ai.index.IndexConstants.ID;

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/SyncUploader.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/SyncUploader.java
@@ -1,4 +1,4 @@
-package uk.gov.moj.cp.migration;
+package uk.gov.moj.cp.migration.index;
 
 import static uk.gov.moj.cp.ai.index.IndexConstants.CHUNK;
 import static uk.gov.moj.cp.ai.index.IndexConstants.CHUNK_INDEX;

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/table/TableCopier.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/table/TableCopier.java
@@ -1,0 +1,169 @@
+package uk.gov.moj.cp.migration.table;
+
+import static java.lang.String.format;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.azure.data.tables.TableClient;
+import com.azure.data.tables.models.TableEntity;
+import com.azure.data.tables.models.TableErrorCode;
+import com.azure.data.tables.models.TableServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Copies every entity from a source Azure Storage table into a (new) target table, optionally rewriting each
+ * row's {@code PartitionKey} to a fixed value. The {@code RowKey} and all data columns are preserved.
+ *
+ * <p>An Azure Table Storage {@code PartitionKey} is part of the entity's immutable primary key — there is no
+ * in-place update. The only way to "change" it is to write a new entity under the new key. This tool therefore
+ * does a <strong>copy into a new table</strong>: it reads the source and upserts a transformed copy into the
+ * target, and <strong>never mutates the source</strong>. That makes a run non-destructive (roll back simply by
+ * continuing to use the source), idempotent (re-runnable — upsert keyed by {@code (PartitionKey, RowKey)}), and
+ * safe to validate before cutover.</p>
+ *
+ * <p>The motivating use case is multi-tenancy: existing single-consumer rows (today keyed by
+ * {@code PartitionKey == RowKey == id}) are migrated so every row's {@code PartitionKey} becomes a fixed
+ * consumer-id string, giving each consumer its own partition going forward.</p>
+ *
+ * <p><strong>Single-threaded by design.</strong> Unlike the search-index copier (which shards because the index
+ * holds hundreds of thousands of vectors and Azure AI Search caps {@code $skip} at 100k), these are small
+ * operational status tables, {@link TableClient#listEntities()} transparently follows continuation tokens, and
+ * the copy is idempotent — so a plain sequential pass is the right altitude.</p>
+ *
+ * <p><strong>Type fidelity.</strong> Property values read from the source already carry their correct Java/EDM
+ * types ({@code OffsetDateTime}, {@code Long}, {@code Double}, {@code Boolean}, {@code UUID}, {@code byte[]});
+ * they are copied as the raw objects and re-upserted with the same types. Decimal columns are stored by the
+ * service as {@code Edm.Double} (EDM has no decimal type), so they round-trip as doubles. The copy deliberately
+ * performs <em>no</em> {@code toString}/re-typing — that would corrupt non-string columns into strings.</p>
+ */
+final class TableCopier {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TableCopier.class);
+
+    /**
+     * Entity-key and service-managed properties returned by {@link TableEntity#getProperties()} that must not be
+     * carried over as data columns: the key fields come from the {@code new TableEntity(pk, rk)} constructor, and
+     * {@code Timestamp} is owned by the service.
+     */
+    private static final Set<String> KEY_PROPERTIES = Set.of("PartitionKey", "RowKey", "Timestamp");
+
+    /**
+     * Prefix of the OData metadata keys the SDK puts in the properties map on read ({@code odata.etag},
+     * {@code odata.metadata}, {@code odata.editLink}, {@code odata.id}, {@code odata.type}). Carrying any of
+     * these over would corrupt the write (e.g. the source etag would scope the upsert to a stale, unrelated etag).
+     */
+    private static final String ODATA_METADATA_PREFIX = "odata.";
+
+    /**
+     * Suffix of the per-property EDM type annotations the SDK leaves in the properties map on read (e.g.
+     * {@code "ResponseGenerationTime@odata.type" -> "Edm.DateTime"}). These must be dropped: the serializer
+     * regenerates the correct annotation from each value's runtime type on write, so re-adding the read-back
+     * annotation as a literal column produces a malformed entity the service rejects with {@code InvalidInput}.
+     * A real column name can contain neither {@code .} nor {@code @}, so this never drops genuine data.
+     */
+    private static final String ODATA_TYPE_SUFFIX = "@odata.type";
+
+    /** Emit a progress line every this many rows. */
+    private static final long LOG_EVERY = 500;
+
+    private final TableClient source;
+    private final TableClient target;
+    /** Fixed PartitionKey to assign to every copied row, or {@code null} to copy the source PartitionKey verbatim. */
+    private final String partitionKeyOverride;
+    /** Cap on the number of rows copied; {@code 0} = copy everything. */
+    private final long maxRecords;
+
+    TableCopier(final TableClient source, final TableClient target,
+                final String partitionKeyOverride, final long maxRecords) {
+        this.source = source;
+        this.target = target;
+        this.partitionKeyOverride = partitionKeyOverride;
+        this.maxRecords = maxRecords;
+    }
+
+    /**
+     * Streams the source table and upserts a copy of every row into the target.
+     *
+     * @return the number of rows copied
+     */
+    long copyAllRows() {
+        ensureTargetTableExists();
+
+        // Only meaningful under override: all copied rows land in one partition, so a repeated RowKey would make
+        // the second upsert silently overwrite the first. Detect and fail loud rather than lose data.
+        final Set<String> seenRowKeys = partitionKeyOverride != null ? new HashSet<>() : null;
+
+        long copied = 0;
+        for (final TableEntity sourceRow : source.listEntities()) {
+            if (maxRecords > 0 && copied >= maxRecords) {
+                LOGGER.info("Reached maxRecords cap ({}); stopping.", maxRecords);
+                break;
+            }
+            copyRow(sourceRow, seenRowKeys);
+            copied++;
+            if (copied % LOG_EVERY == 0) {
+                LOGGER.info("Copied {} rows...", copied);
+            }
+        }
+
+        LOGGER.info("Copy finished — {} row(s) copied from '{}' to '{}'{}.",
+                copied, source.getTableName(), target.getTableName(),
+                partitionKeyOverride != null ? " with partition key overridden to '" + partitionKeyOverride + "'" : "");
+        return copied;
+    }
+
+    private void copyRow(final TableEntity sourceRow, final Set<String> seenRowKeys) {
+        if (seenRowKeys != null && !seenRowKeys.add(sourceRow.getRowKey())) {
+            throw new IllegalStateException(format(
+                    "Duplicate RowKey '%s' under partition-key override: collapsing partitions would overwrite an "
+                            + "already-copied row. Override is unsafe for table '%s' (its RowKeys are not unique). "
+                            + "Source is unchanged.",
+                    sourceRow.getRowKey(), source.getTableName()));
+        }
+        target.upsertEntity(toTargetEntity(sourceRow));
+    }
+
+    /**
+     * Builds the target entity: the (possibly overridden) PartitionKey and the original RowKey via the
+     * constructor, then every source data column copied as its raw value. System properties and nulls are
+     * skipped.
+     */
+    TableEntity toTargetEntity(final TableEntity sourceRow) {
+        final String targetPartitionKey =
+                partitionKeyOverride != null ? partitionKeyOverride : sourceRow.getPartitionKey();
+        final TableEntity targetRow = new TableEntity(targetPartitionKey, sourceRow.getRowKey());
+        for (final Map.Entry<String, Object> property : sourceRow.getProperties().entrySet()) {
+            if (!isKeyOrMetadata(property.getKey()) && property.getValue() != null) {
+                targetRow.addProperty(property.getKey(), property.getValue());
+            }
+        }
+        return targetRow;
+    }
+
+    /**
+     * True for the entity-key/system properties and the OData metadata + per-property type-annotation keys that
+     * {@link TableEntity#getProperties()} returns on read — none of which may be re-sent as data columns.
+     */
+    private static boolean isKeyOrMetadata(final String key) {
+        return KEY_PROPERTIES.contains(key)
+                || key.startsWith(ODATA_METADATA_PREFIX)
+                || key.endsWith(ODATA_TYPE_SUFFIX);
+    }
+
+    /** Idempotent create: ignore "already exists" so a re-run (or a pre-created target) is fine. */
+    private void ensureTargetTableExists() {
+        try {
+            target.createTable();
+            LOGGER.info("Created target table '{}'.", target.getTableName());
+        } catch (final TableServiceException tse) {
+            if (tse.getValue() != null && tse.getValue().getErrorCode() == TableErrorCode.TABLE_ALREADY_EXISTS) {
+                LOGGER.info("Target table '{}' already exists — reusing it.", target.getTableName());
+            } else {
+                throw tse;
+            }
+        }
+    }
+}

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/table/TableMigrationTool.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/table/TableMigrationTool.java
@@ -1,0 +1,83 @@
+package uk.gov.moj.cp.migration.table;
+
+import uk.gov.moj.cp.ai.client.TableClientFactory;
+
+import com.azure.data.tables.TableClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * One-off CLI to copy an Azure Storage table into a new table, optionally rewriting every row's
+ * {@code PartitionKey} to a fixed value — the entry point that wires {@link TableClientFactory} (connection)
+ * to {@link TableCopier} (the copy engine).
+ *
+ * <p>Motivation: the service is going multi-tenant. Existing single-consumer rows (keyed today by
+ * {@code PartitionKey == RowKey == id}) must be migrated so every row's {@code PartitionKey} becomes a fixed
+ * consumer-id string, giving each consumer its own partition. A {@code PartitionKey} is immutable, so this is a
+ * copy-into-new-table; the source is never mutated and a run is idempotent (safe to re-run).</p>
+ *
+ * <p>Connection details come from the environment via {@link TableClientFactory}
+ * ({@code AI_RAG_SERVICE_STORAGE_ACCOUNT_CONNECTION_MODE} = {@code MANAGED_IDENTITY} (default) or
+ * {@code CONNECTION_STRING}; then {@code AI_RAG_SERVICE_TABLE_STORAGE_ENDPOINT} or
+ * {@code AI_RAG_SERVICE_STORAGE_ACCOUNT_CONNECTION_STRING}), so only the table names and the override are
+ * passed as arguments.</p>
+ *
+ * <p>Usage:</p>
+ * <pre>
+ *   mvn -pl ai-document-migration-tool exec:java \
+ *     -Dexec.mainClass=uk.gov.moj.cp.migration.table.TableMigrationTool \
+ *     -Dexec.args="&lt;sourceTable&gt; &lt;targetTable&gt; [partitionKeyOverride] [maxRecords]"
+ *
+ *   # copy every row, rewriting the partition key to a fixed consumer id
+ *   ... -Dexec.args="ingestionOutcome ingestionOutcomeV2 my-consumer-id"
+ *
+ *   # copy verbatim (keep each row's partition key), sample the first 100 rows
+ *   ... -Dexec.args="ingestionOutcome ingestionOutcomeV2 - 100"
+ * </pre>
+ *
+ * <p>{@code partitionKeyOverride} is optional; omit it (or pass a blank / {@code "-"}) to copy partition keys
+ * verbatim. {@code maxRecords} caps the copy for a sample run; {@code 0} (default) copies everything.</p>
+ */
+public final class TableMigrationTool {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TableMigrationTool.class);
+
+    private TableMigrationTool() {
+    }
+
+    public static void main(final String[] args) {
+        if (args.length < 2) {
+            throw new IllegalArgumentException(
+                    "Usage: <sourceTable> <targetTable> [partitionKeyOverride] [maxRecords]");
+        }
+        final String sourceTable = args[0];
+        final String targetTable = args[1];
+        // Treat a blank arg or the "-" placeholder as "no override" so maxRecords can still be supplied positionally.
+        final String partitionKeyOverride =
+                args.length > 2 && !args[2].isBlank() && !"-".equals(args[2]) ? args[2] : null;
+        final long maxRecords = args.length > 3 ? Long.parseLong(args[3]) : 0; // 0 = copy everything
+
+        if (sourceTable.equals(targetTable)) {
+            throw new IllegalArgumentException(
+                    "sourceTable and targetTable must differ — this tool copies into a NEW table.");
+        }
+
+        LOGGER.info("Table copy starting — source='{}', target='{}', partitionKeyOverride={}, maxRecords={}.",
+                sourceTable, targetTable,
+                partitionKeyOverride != null ? "'" + partitionKeyOverride + "'" : "(none — copy verbatim)",
+                maxRecords > 0 ? maxRecords : "(all)");
+
+        final TableClient source = TableClientFactory.getInstance(sourceTable);
+        final TableClient target = TableClientFactory.getInstance(targetTable);
+
+        final long copied = new TableCopier(source, target, partitionKeyOverride, maxRecords).copyAllRows();
+
+        if (maxRecords > 0) {
+            LOGGER.info("Partial copy complete — {} row(s) copied into '{}'. This is a SAMPLE dataset; it is NOT "
+                    + "the full table and must NOT be used for cutover.", copied, targetTable);
+            return;
+        }
+        LOGGER.info("Table copy complete — {} row(s) copied into '{}'. Source '{}' is unchanged.",
+                copied, targetTable, sourceTable);
+    }
+}

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/MigrationToolTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/MigrationToolTest.java
@@ -1,0 +1,57 @@
+package uk.gov.moj.cp.migration;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mockStatic;
+
+import uk.gov.moj.cp.migration.index.IndexMigrationTool;
+import uk.gov.moj.cp.migration.table.TableMigrationTool;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Unit tests for the subcommand dispatcher: it selects a tool by its first argument and forwards the rest, with
+ * no default tool. The per-tool {@code main}s are mocked so nothing touches a live service.
+ */
+class MigrationToolTest {
+
+    @Test
+    void noArgumentsFailsWithUsageListingBothTools() {
+        assertThatThrownBy(() -> MigrationTool.main(new String[]{}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No migration tool specified")
+                .hasMessageContaining("index")
+                .hasMessageContaining("table");
+    }
+
+    @Test
+    void unknownToolFailsWithUsage() {
+        assertThatThrownBy(() -> MigrationTool.main(new String[]{"bogus", "x"}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown migration tool 'bogus'")
+                .hasMessageContaining("index")
+                .hasMessageContaining("table");
+    }
+
+    @Test
+    void indexSubcommandForwardsRemainingArgsToIndexTool() throws Exception {
+        try (MockedStatic<IndexMigrationTool> index = mockStatic(IndexMigrationTool.class)) {
+            MigrationTool.main(new String[]{"index", "ep", "src", "tgt", "alias", "/schema.json", "8"});
+            index.verify(() -> IndexMigrationTool.main(new String[]{"ep", "src", "tgt", "alias", "/schema.json", "8"}));
+        }
+    }
+
+    @Test
+    void tableSubcommandForwardsRemainingArgsToTableTool() throws Exception {
+        try (MockedStatic<TableMigrationTool> table = mockStatic(TableMigrationTool.class)) {
+            MigrationTool.main(new String[]{"table", "srcTbl", "tgtTbl", "consumer-1"});
+            table.verify(() -> TableMigrationTool.main(new String[]{"srcTbl", "tgtTbl", "consumer-1"}));
+        }
+    }
+
+    @Test
+    void helpFlagPrintsUsageAndDoesNotThrow() {
+        assertThatCode(() -> MigrationTool.main(new String[]{"--help"})).doesNotThrowAnyException();
+    }
+}

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/index/BufferedSenderUploaderTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/index/BufferedSenderUploaderTest.java
@@ -1,4 +1,4 @@
-package uk.gov.moj.cp.migration;
+package uk.gov.moj.cp.migration.index;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/index/IndexCopierTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/index/IndexCopierTest.java
@@ -1,4 +1,4 @@
-package uk.gov.moj.cp.migration;
+package uk.gov.moj.cp.migration.index;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/index/IndexMigrationToolTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/index/IndexMigrationToolTest.java
@@ -1,4 +1,4 @@
-package uk.gov.moj.cp.migration;
+package uk.gov.moj.cp.migration.index;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/index/SearchIndexAdminTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/index/SearchIndexAdminTest.java
@@ -1,4 +1,4 @@
-package uk.gov.moj.cp.migration;
+package uk.gov.moj.cp.migration.index;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/index/ShardTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/index/ShardTest.java
@@ -1,4 +1,4 @@
-package uk.gov.moj.cp.migration;
+package uk.gov.moj.cp.migration.index;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/index/SyncUploaderTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/index/SyncUploaderTest.java
@@ -1,4 +1,4 @@
-package uk.gov.moj.cp.migration;
+package uk.gov.moj.cp.migration.index;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/table/TableCopierTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/table/TableCopierTest.java
@@ -1,0 +1,245 @@
+package uk.gov.moj.cp.migration.table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.data.tables.TableClient;
+import com.azure.data.tables.models.TableEntity;
+import com.azure.data.tables.models.TableErrorCode;
+import com.azure.data.tables.models.TableServiceError;
+import com.azure.data.tables.models.TableServiceException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link TableCopier} with the source/target {@link TableClient}s mocked — no live service.
+ * Covers the key transformation ({@code toTargetEntity}: system-property stripping, partition-key override vs
+ * verbatim, type fidelity), the copy loop (cap, idempotent table creation, source never written), and the
+ * fail-loud RowKey-collision guard under override.
+ */
+class TableCopierTest {
+
+    private static final String OVERRIDE = "consumer-123";
+
+    // --- toTargetEntity: transformation -------------------------------------------------------------------
+
+    @Test
+    void stripsSystemPropertiesAndKeepsDataColumnsUnderOverride() {
+        final TableEntity source = mock(TableEntity.class);
+        when(source.getPartitionKey()).thenReturn("old-pk");
+        when(source.getRowKey()).thenReturn("rk-1");
+        final Map<String, Object> props = new LinkedHashMap<>();
+        props.put("PartitionKey", "old-pk");
+        props.put("RowKey", "rk-1");
+        props.put("Timestamp", OffsetDateTime.parse("2024-01-01T00:00:00Z"));
+        props.put("odata.etag", "W/\"datetime'2024'\"");
+        props.put("DocumentStatus", "INGESTED");
+        props.put("DocumentId", "rk-1");
+        when(source.getProperties()).thenReturn(props);
+
+        final TableEntity target = copier(OVERRIDE, 0).toTargetEntity(source);
+
+        assertThat(target.getPartitionKey()).isEqualTo(OVERRIDE);
+        assertThat(target.getRowKey()).isEqualTo("rk-1");
+        assertThat(target.getProperties())
+                .containsEntry("DocumentStatus", "INGESTED")
+                .containsEntry("DocumentId", "rk-1")
+                .doesNotContainKey("Timestamp")
+                .doesNotContainKey("odata.etag");
+    }
+
+    @Test
+    void preservesNonStringPropertyTypesAsRawObjects() {
+        final OffsetDateTime when = OffsetDateTime.parse("2024-06-01T12:30:00Z");
+        final UUID guid = UUID.fromString("00000000-0000-0000-0000-000000000abc");
+        final TableEntity source = mock(TableEntity.class);
+        when(source.getPartitionKey()).thenReturn("pk");
+        when(source.getRowKey()).thenReturn("rk");
+        final Map<String, Object> props = new LinkedHashMap<>();
+        props.put("ResponseGenerationTime", when);
+        props.put("ResponseGenerationDuration", 4200L);
+        props.put("GroundednessScore", 0.875d);
+        props.put("Flagged", Boolean.TRUE);
+        props.put("Correlation", guid);
+        when(source.getProperties()).thenReturn(props);
+
+        final Map<String, Object> copied = copier(null, 0).toTargetEntity(source).getProperties();
+
+        assertThat(copied.get("ResponseGenerationTime")).isSameAs(when);
+        assertThat(copied.get("ResponseGenerationDuration")).isEqualTo(4200L).isInstanceOf(Long.class);
+        assertThat(copied.get("GroundednessScore")).isEqualTo(0.875d).isInstanceOf(Double.class);
+        assertThat(copied.get("Flagged")).isEqualTo(Boolean.TRUE);
+        assertThat(copied.get("Correlation")).isSameAs(guid);
+    }
+
+    @Test
+    void stripsPerPropertyTypeAnnotationsAndAllOdataMetadataKeys() {
+        // On read the SDK leaves "<col>@odata.type" annotations and odata.* metadata keys in the properties map.
+        // Re-sending them as literal columns produces a malformed entity the service rejects with InvalidInput,
+        // so they must be dropped (the serializer regenerates the type tags from the value types on write).
+        final OffsetDateTime when = OffsetDateTime.parse("2024-06-01T12:30:00Z");
+        final TableEntity source = mock(TableEntity.class);
+        when(source.getPartitionKey()).thenReturn("pk");
+        when(source.getRowKey()).thenReturn("rk");
+        final Map<String, Object> props = new LinkedHashMap<>();
+        props.put("ResponseGenerationTime", when);
+        props.put("ResponseGenerationTime@odata.type", "Edm.DateTime");
+        props.put("ResponseGenerationDuration", 4200L);
+        props.put("ResponseGenerationDuration@odata.type", "Edm.Int64");
+        props.put("odata.etag", "W/\"datetime'2024'\"");
+        props.put("odata.editLink", "Table(PartitionKey='pk',RowKey='rk')");
+        props.put("odata.id", "https://acct.table.core.windows.net/Table(...)");
+        props.put("odata.metadata", "https://acct.table.core.windows.net/$metadata#Table");
+        props.put("LlmResponse", "an answer");
+        when(source.getProperties()).thenReturn(props);
+
+        final Map<String, Object> copied = copier(OVERRIDE, 0).toTargetEntity(source).getProperties();
+
+        // Only the real data columns survive; their raw typed values are intact.
+        assertThat(copied.get("ResponseGenerationTime")).isSameAs(when);
+        assertThat(copied.get("ResponseGenerationDuration")).isEqualTo(4200L);
+        assertThat(copied.get("LlmResponse")).isEqualTo("an answer");
+        assertThat(copied.keySet())
+                .noneMatch(k -> k.endsWith("@odata.type"))
+                .noneMatch(k -> k.startsWith("odata."));
+    }
+
+    @Test
+    void verbatimCopyKeepsSourcePartitionKeyWhenOverrideAbsent() {
+        final TableEntity target = copier(null, 0).toTargetEntity(entity("orig-pk", "rk-1"));
+        assertThat(target.getPartitionKey()).isEqualTo("orig-pk");
+        assertThat(target.getRowKey()).isEqualTo("rk-1");
+    }
+
+    @Test
+    void skipsNullPropertyValues() {
+        final TableEntity source = mock(TableEntity.class);
+        when(source.getPartitionKey()).thenReturn("pk");
+        when(source.getRowKey()).thenReturn("rk");
+        final Map<String, Object> props = new LinkedHashMap<>();
+        props.put("Reason", null);
+        props.put("DocumentStatus", "FAILED");
+        when(source.getProperties()).thenReturn(props);
+
+        assertThat(copier(null, 0).toTargetEntity(source).getProperties())
+                .containsEntry("DocumentStatus", "FAILED")
+                .doesNotContainKey("Reason");
+    }
+
+    // --- copyAllRows: loop behaviour ----------------------------------------------------------------------
+
+    @Test
+    void copiesEveryRowAndNeverWritesToSource() {
+        final TableClient source = sourceWith(entity("a", "rk-a"), entity("b", "rk-b"));
+        final TableClient target = mock(TableClient.class);
+
+        final long copied = new TableCopier(source, target, OVERRIDE, 0).copyAllRows();
+
+        assertThat(copied).isEqualTo(2);
+        verify(target, times(2)).upsertEntity(any());
+        verify(source, never()).upsertEntity(any());
+        verify(source, never()).createEntity(any());
+        verify(source, never()).deleteEntity(any());
+    }
+
+    @Test
+    void maxRecordsCapsTheNumberOfRowsCopied() {
+        final TableClient source = sourceWith(
+                entity("a", "1"), entity("b", "2"), entity("c", "3"), entity("d", "4"), entity("e", "5"));
+        final TableClient target = mock(TableClient.class);
+
+        final long copied = new TableCopier(source, target, OVERRIDE, 3).copyAllRows();
+
+        assertThat(copied).isEqualTo(3);
+        verify(target, times(3)).upsertEntity(any());
+    }
+
+    @Test
+    void duplicateRowKeyUnderOverrideFailsLoud() {
+        // Two rows that share a RowKey but live in different source partitions: collapsing to one partition
+        // would make the second upsert overwrite the first, so the copy must abort.
+        final TableClient source = sourceWith(entity("pk-1", "dup"), entity("pk-2", "dup"));
+        final TableClient target = mock(TableClient.class);
+
+        assertThatThrownBy(() -> new TableCopier(source, target, OVERRIDE, 0).copyAllRows())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Duplicate RowKey")
+                .hasMessageContaining("dup");
+    }
+
+    @Test
+    void duplicateRowKeyAllowedWhenOverrideAbsent() {
+        // Without override each row keeps its own partition, so identical RowKeys are distinct entities.
+        final TableClient source = sourceWith(entity("pk-1", "dup"), entity("pk-2", "dup"));
+        final TableClient target = mock(TableClient.class);
+
+        assertThatCode(() -> new TableCopier(source, target, null, 0).copyAllRows()).doesNotThrowAnyException();
+        verify(target, times(2)).upsertEntity(any());
+    }
+
+    // --- ensureTargetTableExists --------------------------------------------------------------------------
+
+    @Test
+    void tableAlreadyExistsIsSwallowed() {
+        final TableClient source = sourceWith(entity("a", "rk-a"));
+        final TableClient target = mock(TableClient.class);
+        // Build the exception before the when(...) — its nested stubbing must finish before the outer one starts.
+        final TableServiceException alreadyExists = tableServiceException(TableErrorCode.TABLE_ALREADY_EXISTS);
+        when(target.createTable()).thenThrow(alreadyExists);
+
+        assertThatCode(() -> new TableCopier(source, target, OVERRIDE, 0).copyAllRows()).doesNotThrowAnyException();
+        verify(target).upsertEntity(any());
+    }
+
+    @Test
+    void otherCreateTableErrorIsRethrown() {
+        final TableClient source = mock(TableClient.class);
+        final TableClient target = mock(TableClient.class);
+        final TableServiceException otherError = tableServiceException(TableErrorCode.INVALID_INPUT);
+        when(target.createTable()).thenThrow(otherError);
+
+        assertThatThrownBy(() -> new TableCopier(source, target, OVERRIDE, 0).copyAllRows())
+                .isInstanceOf(TableServiceException.class);
+        verify(source, never()).listEntities();
+    }
+
+    // --- helpers ------------------------------------------------------------------------------------------
+
+    private static TableCopier copier(final String override, final long maxRecords) {
+        return new TableCopier(mock(TableClient.class), mock(TableClient.class), override, maxRecords);
+    }
+
+    private static TableEntity entity(final String partitionKey, final String rowKey) {
+        return new TableEntity(partitionKey, rowKey).addProperty("DocumentStatus", "INGESTED");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static TableClient sourceWith(final TableEntity... rows) {
+        final TableClient source = mock(TableClient.class);
+        final PagedIterable<TableEntity> paged = mock(PagedIterable.class);
+        when(paged.iterator()).thenReturn(List.of(rows).iterator());
+        when(source.listEntities()).thenReturn(paged);
+        return source;
+    }
+
+    private static TableServiceException tableServiceException(final TableErrorCode code) {
+        final TableServiceError error = mock(TableServiceError.class);
+        when(error.getErrorCode()).thenReturn(code);
+        final TableServiceException tse = mock(TableServiceException.class);
+        when(tse.getValue()).thenReturn(error);
+        return tse;
+    }
+}

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/table/TableMigrationToolTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/table/TableMigrationToolTest.java
@@ -1,0 +1,120 @@
+package uk.gov.moj.cp.migration.table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import uk.gov.moj.cp.ai.client.TableClientFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.azure.data.tables.TableClient;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+/**
+ * Unit tests for the {@code main} wiring — argument parsing and which collaborators are invoked — with the
+ * static {@link TableClientFactory} and the constructed {@link TableCopier} mocked. No live service is
+ * contacted.
+ */
+class TableMigrationToolTest {
+
+    @Test
+    void mainRejectsTooFewArguments() {
+        assertThatThrownBy(() -> TableMigrationTool.main(new String[]{"only-source"}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Usage:");
+    }
+
+    @Test
+    void mainRejectsSameSourceAndTarget() {
+        assertThatThrownBy(() -> TableMigrationTool.main(new String[]{"same", "same"}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must differ");
+    }
+
+    @Test
+    void fullCopyWiresClientsAndRunsCopierWithDefaults() {
+        final TableClient source = mock(TableClient.class);
+        final TableClient target = mock(TableClient.class);
+        final List<List<Object>> ctorArgs = new ArrayList<>();
+
+        try (MockedStatic<TableClientFactory> factory = mockStatic(TableClientFactory.class);
+             MockedConstruction<TableCopier> copier = mockConstruction(TableCopier.class, (m, ctx) -> {
+                 ctorArgs.add(new ArrayList<>(ctx.arguments()));
+                 when(m.copyAllRows()).thenReturn(7L);
+             })) {
+
+            factory.when(() -> TableClientFactory.getInstance("src")).thenReturn(source);
+            factory.when(() -> TableClientFactory.getInstance("tgt")).thenReturn(target);
+
+            TableMigrationTool.main(new String[]{"src", "tgt"});
+
+            factory.verify(() -> TableClientFactory.getInstance("src"));
+            factory.verify(() -> TableClientFactory.getInstance("tgt"));
+            assertThat(copier.constructed()).hasSize(1);
+            // (source, target, partitionKeyOverride=null, maxRecords=0)
+            assertThat(ctorArgs.get(0)).containsExactly(source, target, null, 0L);
+            verify(copier.constructed().get(0)).copyAllRows();
+        }
+    }
+
+    @Test
+    void parsesPartitionKeyOverrideAndMaxRecords() {
+        runAndCaptureCtorArgs(new String[]{"src", "tgt", "consumer-123", "500"},
+                args -> assertThat(args).containsExactly(mockSource(), mockTarget(), "consumer-123", 500L));
+    }
+
+    @Test
+    void blankOverrideIsTreatedAsNull() {
+        runAndCaptureCtorArgs(new String[]{"src", "tgt", "", "0"},
+                args -> assertThat(args.get(2)).isNull());
+    }
+
+    @Test
+    void dashPlaceholderOverrideIsTreatedAsNull() {
+        runAndCaptureCtorArgs(new String[]{"src", "tgt", "-", "10"},
+                args -> {
+                    assertThat(args.get(2)).isNull();
+                    assertThat(args.get(3)).isEqualTo(10L);
+                });
+    }
+
+    // --- helpers ------------------------------------------------------------------------------------------
+
+    // Sentinels so the override/maxRecords assertions can reference the exact stubbed clients by identity.
+    private static final TableClient SOURCE = mock(TableClient.class);
+    private static final TableClient TARGET = mock(TableClient.class);
+
+    private static TableClient mockSource() {
+        return SOURCE;
+    }
+
+    private static TableClient mockTarget() {
+        return TARGET;
+    }
+
+    private void runAndCaptureCtorArgs(final String[] args, final java.util.function.Consumer<List<Object>> assertion) {
+        final List<List<Object>> ctorArgs = new ArrayList<>();
+        try (MockedStatic<TableClientFactory> factory = mockStatic(TableClientFactory.class);
+             MockedConstruction<TableCopier> copier = mockConstruction(TableCopier.class, (m, ctx) -> {
+                 ctorArgs.add(new ArrayList<>(ctx.arguments()));
+                 when(m.copyAllRows()).thenReturn(0L);
+             })) {
+
+            factory.when(() -> TableClientFactory.getInstance("src")).thenReturn(SOURCE);
+            factory.when(() -> TableClientFactory.getInstance("tgt")).thenReturn(TARGET);
+
+            TableMigrationTool.main(args);
+
+            assertThat(copier.constructed()).hasSize(1);
+            assertion.accept(ctorArgs.get(0));
+        }
+    }
+}


### PR DESCRIPTION
## What & why

The RAG service is going **multi-tenant**. Today both Azure Storage tables hold a single consumer's data, keyed by `PartitionKey == RowKey == id`. Going forward each consumer is its own partition (`PartitionKey = consumerId`). Because a Table Storage `PartitionKey` is **immutable**, existing rows can't be updated in place — they must be re-written under the new key.

This adds a **table-to-table copy tool** to `ai-document-migration-tool` (alongside the existing index→index copier) that copies every row from a source table into a new table, optionally **rewriting each row's `PartitionKey`** to a fixed value while preserving the `RowKey` and all data columns. It is **copy-only** (source never mutated → instant rollback), **idempotent** (upsert keyed by `(PartitionKey, RowKey)` → re-runnable), and single-threaded (these are small operational tables, unlike the sharded ~340k-vector index copier).

> Scope: this tool performs **only the data copy**. The `consumerId` plumbing through the application's read/write paths is a separate change; cut over together, with the override value matching the consumer-id the app adopts.

## Changes

- **`TableCopier`** — ensures the target table (idempotent, swallows `TABLE_ALREADY_EXISTS`), streams `listEntities()`, applies the partition-key override, strips entity-key + OData metadata/`@odata.type` keys so typed columns round-trip cleanly, and **fails loud on RowKey collisions** under override (would otherwise silently overwrite).
- **`TableMigrationTool`** — entry point; resolves source/target clients via the shared `TableClientFactory` (connection from env, same config as the deployed functions).
- **`MigrationTool`** — a single dispatcher (jar `Main-Class`) that selects the tool by its first argument (`index` | `table`) with **no default**, so a bulk migration is never triggered implicitly. Uniform invocation: `… exec:java -Dexec.args="table …"` and `docker run img table …` (no entrypoint override).
- **Package reorg** — existing index classes → `uk.gov.moj.cp.migration.index`; new table classes → `uk.gov.moj.cp.migration.table` (relocation only, no logic change).
- **pom** — add `azure-data-tables` (BOM-managed); `migration.mainClass` → the dispatcher.
- **Docs** — README table section + container subsection + subcommand model; Dockerfile comment.

## Type-fidelity note

The SDK returns `@odata.type` annotation keys (and `odata.*` metadata) in `getProperties()` on read; re-sending them produces an `InvalidInput` the service rejects. The copier strips them and lets the serializer regenerate type tags from each value's runtime type, so `OffsetDateTime` / `Long` / `Double` columns copy faithfully. Decimal columns are stored as `Edm.Double` (no EDM decimal type) and round-trip as doubles.

## Testing

- `mvn -pl ai-document-migration-tool -am clean test` → **54 passing** (new `TableCopierTest`, `TableMigrationToolTest`, `MigrationToolTest`; relocated index tests).
- Smoke-tested the packaged jar: `Main-Class` is the dispatcher; `--help` / no-args / unknown-tool behave as expected.