### PR TITLE
Wire reasoning_effort into OpenAiChatService; gate verbosity to reasoning models

### DIFF
--- a/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/service/OpenAiChatService.java
+++ b/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/service/OpenAiChatService.java
@@ -18,6 +18,8 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.openai.client.OpenAIClient;
+import com.openai.models.Reasoning;
+import com.openai.models.ReasoningEffort;
 import com.openai.models.responses.Response;
 import com.openai.models.responses.ResponseCreateParams;
 import com.openai.models.responses.ResponseOutputItem;
@@ -35,10 +37,30 @@ public class OpenAiChatService implements ChatService {
     private static final double TEMPERATURE = 0.0;
     private static final double TOP_P = 0.0;
 
+    /**
+     * Output verbosity for GPT-5 reasoning models, applied via the Responses API
+     * {@code text.verbosity}. Configurable via the {@code LLM_MODEL_RESPONSE_VERBOSITY} env var;
+     * allowed values: {@code low | medium | high} (default {@link #DEFAULT_VERBOSITY}). Ignored by
+     * non-reasoning models.
+     */
+    private static final String DEFAULT_VERBOSITY = "low";
+
+    /**
+     * Reasoning effort for reasoning models (gpt-5/o-series), applied via the Responses API
+     * {@code reasoning.effort}. Configurable via the {@code LLM_REASONING_EFFORT} env var; allowed
+     * values: {@code none | minimal | low | medium | high | xhigh} (default
+     * {@link #DEFAULT_REASONING_EFFORT}). Lower effort frees output-token budget (less truncation of
+     * the answer/JSON) and tends to yield more concise output. Ignored for non-reasoning models
+     * (e.g. gpt-4o). Mirrors the same control in {@link AzureChatService}.
+     */
+    private static final String LLM_REASONING_EFFORT = "LLM_REASONING_EFFORT";
+    private static final String DEFAULT_REASONING_EFFORT = "none";
+
     private final OpenAIClient openAIClient;
     private final String deploymentName;
     private final int maxTokens;
     private final String verbosity;
+    private final String reasoningEffort;
 
     public OpenAiChatService(final String endpoint, final String deploymentName) {
 
@@ -49,14 +71,16 @@ public class OpenAiChatService implements ChatService {
         this.openAIClient = OpenAiClientFactory.getInstance(endpoint);
 
         maxTokens = getRequiredEnvAsInteger(LLM_MODEL_RESPONSE_MAX_TOKENS, MAX_TOKENS);
-        verbosity = getRequiredEnv(LLM_MODEL_RESPONSE_VERBOSITY, "low");
+        verbosity = getRequiredEnv(LLM_MODEL_RESPONSE_VERBOSITY, DEFAULT_VERBOSITY);
+        reasoningEffort = getRequiredEnv(LLM_REASONING_EFFORT, DEFAULT_REASONING_EFFORT);
     }
 
     protected OpenAiChatService(final OpenAIClient openAIClient, final String deploymentName) {
         this.deploymentName = deploymentName;
         this.openAIClient = openAIClient;
         maxTokens = parseInt(MAX_TOKENS);
-        verbosity = getRequiredEnv(LLM_MODEL_RESPONSE_VERBOSITY, "low");
+        verbosity = getRequiredEnv(LLM_MODEL_RESPONSE_VERBOSITY, DEFAULT_VERBOSITY);
+        reasoningEffort = getRequiredEnv(LLM_REASONING_EFFORT, DEFAULT_REASONING_EFFORT);
         LOGGER.info("Returning initialized OpenAI client for chat.");
     }
 
@@ -72,15 +96,21 @@ public class OpenAiChatService implements ChatService {
                 .input(userInstruction)
                 .maxOutputTokens((long) maxTokens);
 
-        if (!reasoningModel) {
+        if (reasoningModel) {
+            paramsBuilder.reasoning(Reasoning.builder()
+                    .effort(ReasoningEffort.of(reasoningEffort.trim().toLowerCase()))
+                    .build());
+            // verbosity is a GPT-5 reasoning-model Responses-API control. Non-reasoning models
+            // (e.g. gpt-4o) REJECT it — `gpt-4o` returns 400 "Unsupported value: 'low' ... Supported
+            // values are: 'medium'" — so only set it for reasoning models, alongside reasoning_effort.
+            paramsBuilder.text(ResponseTextConfig.builder()
+                    .verbosity(ResponseTextConfig.Verbosity.of(verbosity))
+                    .build());
+            LOGGER.info("Applied reasoning_effort='{}', verbosity='{}' for reasoning model '{}'",
+                    reasoningEffort, verbosity, deploymentName);
+        } else {
             paramsBuilder.temperature(TEMPERATURE).topP(TOP_P);
         }
-
-        // verbosity is honored on the Responses API for GPT-5 reasoning models; silently ignored
-        // by other models. This allows users to configure more detailed response status information for troubleshooting without affecting non-reasoning models.
-        paramsBuilder.text(ResponseTextConfig.builder()
-                .verbosity(ResponseTextConfig.Verbosity.of(verbosity))
-                .build());
 
         try {
             final Response response = openAIClient.responses().create(paramsBuilder.build());

--- a/ai-document-shared-artefacts/src/test/java/uk/gov/moj/cp/ai/service/OpenAiChatServiceTest.java
+++ b/ai-document-shared-artefacts/src/test/java/uk/gov/moj/cp/ai/service/OpenAiChatServiceTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.openai.client.OpenAIClient;
+import com.openai.models.ReasoningEffort;
 import com.openai.models.responses.Response;
 import com.openai.models.responses.ResponseCreateParams;
 import com.openai.models.responses.ResponseOutputItem;
@@ -110,7 +111,7 @@ class OpenAiChatServiceTest {
     }
 
     @Test
-    @DisplayName("Reasoning-model deployments (gpt-5/o-series) omit temperature and top_p")
+    @DisplayName("Reasoning-model deployments (gpt-5/o-series) omit temperature/top_p and default reasoning_effort to none")
     void reasoningModelDeploymentOmitsSamplingParameters() throws Exception {
         assertSamplingParameters("gpt-5-mini", true);
         assertSamplingParameters("gpt5-deployment", true);
@@ -171,9 +172,15 @@ class OpenAiChatServiceTest {
         if (isReasoning) {
             assertTrue(params.temperature().isEmpty(), "reasoning model must not set temperature: " + deploymentName);
             assertTrue(params.topP().isEmpty(), "reasoning model must not set top_p: " + deploymentName);
+            assertTrue(params.reasoning().isPresent(), "reasoning model must set reasoning: " + deploymentName);
+            assertEquals(Optional.of(ReasoningEffort.NONE), params.reasoning().get().effort(),
+                    "reasoning model must default reasoning_effort to none: " + deploymentName);
+            assertTrue(params.text().isPresent(), "reasoning model must set verbosity (text config): " + deploymentName);
         } else {
             assertEquals(Optional.of(0.0), params.temperature(), "non-reasoning model must set temperature=0.0: " + deploymentName);
             assertEquals(Optional.of(0.0), params.topP(), "non-reasoning model must set top_p=0.0: " + deploymentName);
+            assertTrue(params.reasoning().isEmpty(), "non-reasoning model must not set reasoning: " + deploymentName);
+            assertTrue(params.text().isEmpty(), "non-reasoning model must NOT set verbosity (gpt-4o rejects 'low'): " + deploymentName);
         }
     }
 

--- a/ai-document-system-prompt-harness-eval/src/main/resources/system-prompt-evaluation-openai-sdk.md
+++ b/ai-document-system-prompt-harness-eval/src/main/resources/system-prompt-evaluation-openai-sdk.md
@@ -1,0 +1,110 @@
+# System prompt evaluation — extending to the OpenAI SDK path
+
+> Companion to `system-prompt-evaluation-cross-model.md`. That document evaluated the
+> answer-retrieval prompt across GPT-4o and GPT-5.1 on the **Azure OpenAI SDK** path
+> (`AzureChatService`, Chat Completions API). This note extends the exercise to the
+> **OpenAI SDK** path (`OpenAiChatService`, Responses API), since the service can run
+> either via `LLM_CHAT_SERVICE_PROVIDER` (`azure` | `openai`). Same prospective framing:
+> the move to the GPT-5.1 reasoning model is **under evaluation, not in production**.
+
+## 1. Why extend to the OpenAI SDK
+
+The service has two interchangeable `ChatService` implementations, selected by
+`LLM_CHAT_SERVICE_PROVIDER`:
+
+| | `AzureChatService` (`azure`) | `OpenAiChatService` (`openai`) |
+|---|---|---|
+| SDK / API | `com.azure.ai.openai`, **Chat Completions** | `com.openai`, **Responses API** |
+| Token cap | `max_completion_tokens` | `maxOutputTokens` |
+| Reasoning-model control | `reasoning_effort` | `reasoning.effort` |
+| Verbosity control | not available in the SDK | `text.verbosity` |
+| Truncation signal | `finish_reason=length` / empty | `incompleteDetails` / empty |
+
+The earlier evaluation only exercised the Azure path. Three of the four changes it
+produced are **provider-agnostic** and already protect both paths:
+- the improved prompt (`baseline-with-improvements`) — passed as the system instruction;
+- the `CitationProcessor` hardening — post-processing, after the chat call;
+- the `ChunkFormatterUtility` `CHUNK_ID` removal — input formatting, before the chat call.
+
+The fourth — `reasoning_effort=none` — was **Azure-only**, so the OpenAI path was
+unvalidated and parameterised differently. This note closes that gap.
+
+## 2. Two defects found while wiring up the OpenAI path
+
+1. **`reasoning_effort` was never set on the OpenAI path.** `OpenAiChatService` omitted
+   `temperature`/`top_p` for reasoning models but applied no reasoning control, so gpt-5.1
+   ran at the model-default effort — the very budget-exhaustion risk the Azure default of
+   `none` was introduced to remove. **Fix:** added a configurable `LLM_REASONING_EFFORT`
+   (default `none`; allowed `none|minimal|low|medium|high|xhigh`) applied via the Responses
+   API `reasoning.effort`, mirroring `AzureChatService`.
+
+2. **`verbosity=low` was sent to every model and gpt-4o rejected it.** The code applied
+   `text.verbosity` unconditionally (a comment claimed it was "silently ignored by other
+   models"). In practice gpt-4o returns `400: Unsupported value: 'low' is not supported with
+   the 'gpt-4o-2024-11-20' model. Supported values are: 'medium'`, which failed **every**
+   gpt-4o call on the OpenAI path. **Fix:** gated `verbosity` to reasoning models only
+   (exactly as `temperature`/`top_p` are gated for non-reasoning models).
+
+Both fixes are covered by `OpenAiChatServiceTest` (reasoning-effort default `none` and
+verbosity present for reasoning models / absent for non-reasoning).
+
+## 3. The run (OpenAI SDK) vs the earlier run (Azure SDK)
+
+Both: 2 reps × 2 prompts (`baseline-production`, `baseline-with-improvements`) × 2 models
+(`gpt-4o`, `gpt-5.1`) × 10 queries; `reasoning_effort=none`; `max_completion_tokens=7000`.
+
+| Dimension | Azure SDK | OpenAI SDK |
+|---|---|---|
+| Calls generated (`ok`) | 80/80 | 80/80 |
+| Empty / reasoning-exhaustion failures | 0 | 0 |
+| gpt-5.1 + improved prompt — citations (`match`, 6 findings queries) | **6/6 clean (2/2 each)** | **6/6 clean (2/2 each)** |
+| gpt-4o — citations | messy (model trait) | messy (slightly worse) |
+| GUID-derived / hex citationIds | none | none |
+| gpt-5.1 clean-JSON misses on the long `Chronology` | 2 reps output-truncated (`finish_reason=length`) | 1 rep catastrophic counter-loop (`[1]…[2612]`, no JSON block) |
+
+gpt-5.1 + improved prompt — verbosity & coverage (mean over the 5 substantive findings queries):
+
+| | Azure SDK | OpenAI SDK |
+|---|---|---|
+| answer words | ~2,078 | ~2,140 |
+| distinct citations | ~18.6 | ~20.0 |
+
+Per-query words (Azure → OpenAI): Summary 2282→1615, Applications 378→261, **Chronology
+2623→3338**, Prosecution 2553→2728, Witnesses 2556→2757.
+
+## 4. Outcome
+
+1. **Both SDK paths now work for the gpt-5.1 migration** — but only after the two defects
+   above were fixed. Before the fixes the OpenAI path had no reasoning control and failed
+   every gpt-4o call.
+2. **Citation quality is equivalent and good on both SDKs.** The improved prompt on gpt-5.1
+   is 100% clean (`match` 2/2 across all six findings queries) on both. gpt-4o remains the
+   messier model on both (marginally worse on the OpenAI Responses path). No GUID-derived ids
+   on either — the OpenAI run's only large ids were a single sequential counter-loop, which
+   the `CitationProcessor` catastrophic-bracket guard strips before it reaches a user.
+3. **`verbosity=low` is *not* a conciseness win at scale.** A single-query smoke suggested the
+   OpenAI path was much shorter, but across the full set the mean word counts are essentially
+   equal (~2,078 vs ~2,140) and the per-query effect is mixed (Summary shorter, Chronology
+   longer). gpt-5.1's length is driven by citation coverage, not the verbosity knob.
+4. **Reliability is comparable, with the same weak spot.** The long `Chronology` query is where
+   gpt-5.1 occasionally fails to emit a clean citation block — Azure via output-token
+   truncation, OpenAI via a counter-loop. Different mechanism, same locus; the improved prompt
+   avoids it on both (truncation-free on gpt-5.1), and the `CitationProcessor` guard degrades
+   the rare failure gracefully.
+
+**Net:** the prompt/citation improvements are SDK-agnostic and hold on both paths. The
+reliability/length levers are now at parity — `reasoning_effort=none` on both, `verbosity`
+correctly scoped to reasoning models on the OpenAI path. **Choosing the OpenAI vs Azure SDK is
+a reliability/operations decision, not a citation-quality one, and verbosity is not a deciding
+factor.**
+
+## 5. Configuration parity (both providers, reasoning models)
+
+| Env var | `azure` / `AzureChatService` | `openai` / `OpenAiChatService` |
+|---|---|---|
+| `LLM_REASONING_EFFORT` | applied (default `none`) | **now applied (default `none`)** |
+| `LLM_MODEL_RESPONSE_VERBOSITY` | n/a (SDK lacks it) | applied to reasoning models only (`low|medium|high`) |
+| `LLM_MODEL_RESPONSE_MAX_TOKENS` | `max_completion_tokens` | `maxOutputTokens` |
+
+> Re-run on either path via the harness: set `LLM_CHAT_SERVICE_PROVIDER` in `.env` and run
+> `./run-harness.sh`.


### PR DESCRIPTION
## Why

Extends the cross-model system-prompt evaluation (PR #97) to the **OpenAI SDK** path. The service can run via either `ChatService` implementation (`LLM_CHAT_SERVICE_PROVIDER` = `azure` | `openai`); the earlier evaluation only exercised `AzureChatService`. This brings `OpenAiChatService` (Responses API) to parity for the **prospective** GPT-5.1 migration (still under evaluation, **not in production**).

## Defects fixed (found while wiring up the OpenAI path)

1. **`reasoning_effort` was never set on the OpenAI path.** `OpenAiChatService` omitted `temperature`/`top_p` for reasoning models but applied no reasoning control, so gpt-5.1 ran at the model-default effort — the budget-exhaustion / truncation risk the Azure default of `none` was introduced to remove. **Fix:** configurable `LLM_REASONING_EFFORT` (default `none`; allowed `none|minimal|low|medium|high|xhigh`), applied via the Responses API `reasoning.effort`, mirroring `AzureChatService`.
2. **`verbosity=low` was sent to every model; gpt-4o rejects it.** It was applied unconditionally — gpt-4o returns `400: Unsupported value: 'low' ... Supported values are: 'medium'`, which failed **every** gpt-4o call on the OpenAI path. **Fix:** gate `text.verbosity` to reasoning models only (as `temperature`/`top_p` are gated for non-reasoning).

## Tests
- `OpenAiChatServiceTest` now asserts: reasoning models default `reasoning_effort` to `none` and carry `verbosity`; non-reasoning models set neither. 9/9 pass; full reactor build green.

## Docs
- `system-prompt-evaluation-openai-sdk.md` (companion to the cross-model doc) records the effort and the latest cross-SDK comparison run.

## Outcome of the comparison run (2 reps × 2 prompts × gpt-4o + gpt-5.1 × 10 queries, both SDKs)
- **Both SDK paths now work** for the gpt-5.1 migration (after the two fixes).
- **Citation quality is equivalent and good**: the improved prompt on gpt-5.1 is clean (`match` 2/2 across all six findings queries) on both SDKs; no GUID-derived ids.
- **`verbosity=low` is not a conciseness win at scale**: mean gpt-5.1 answer length is ~equal across SDKs (~2,078 vs ~2,140 words); per-query effect is mixed.
- **Reliability comparable**, same weak spot: the long `Chronology` query is where gpt-5.1 can fail to emit a clean JSON block (Azure: output truncation; OpenAI: a counter-loop) — the improved prompt avoids it and the `CitationProcessor` guard degrades gracefully.

**Net:** prompt/citation improvements are SDK-agnostic; the reliability/length levers are now at parity. Choosing OpenAI vs Azure SDK is a reliability/ops decision, not a citation-quality one.