### PR TITLE
Package migration tool as a single distribution archive

### DIFF
--- a/ai-document-migration-tool/Dockerfile
+++ b/ai-document-migration-tool/Dockerfile
@@ -1,12 +1,15 @@
-# Runtime-only image for the one-off index-migration tool.
+# Runtime-only image for the migration tool.
 #
-# The jar + dependency lib/ are built ON THE HOST first (the Maven build resolves through the internal
-# Artifactory mirror configured in ~/.m2/settings.xml, which a clean in-image build / cloud build agent
-# cannot reach). This image just packages those prebuilt artifacts into a clean JRE.
+# The artefact is a single distribution archive — the thin app jar + its dependency jars under lib/,
+# bundled into one tar.gz by maven-assembly-plugin. It is built ON THE HOST / in CI (Maven resolves
+# through the internal Artifactory mirror, which a clean in-image build cannot reach) and either taken
+# from target/ locally or pulled from Artifactory in CI. This image just unpacks it into a clean JRE.
 #
-# Build context is THIS module directory (so target/ is available):
+# Build the artefact, then the image (build context = this module dir):
 #   mvn -pl ai-document-migration-tool -am -DskipTests package
-#   docker build -f ai-document-migration-tool/Dockerfile -t ai-index-migration:1 ai-document-migration-tool
+#   docker build -f ai-document-migration-tool/Dockerfile -t ai-rag-migration:1 ai-document-migration-tool
+# In CI, download the dist tar.gz from Artifactory into the build context and override the path:
+#   docker build --build-arg DIST_ARCHIVE=ai-document-migration-tool-<ver>-dist.tar.gz ...
 #
 # The image is deliberately clean: no Azure CLI, no secrets, no mounts. Authentication is resolved at
 # run time by DefaultAzureCredential — locally via a service principal in the environment
@@ -19,11 +22,12 @@ WORKDIR /app
 # Non-root runtime user (fixed high uid; not --system, whose uids must stay below 1000).
 RUN useradd --uid 10001 --create-home appuser
 
-# Thin application jar (its manifest carries Main-Class + a lib/-relative Class-Path) plus the
-# dependency jars. Keeping dependencies as separate jars preserves each one's META-INF/services, so
-# the Azure SDK's ServiceLoader-based HTTP client / credential discovery works without uber-jar merging.
-COPY target/lib /app/lib
-COPY target/ai-document-migration-tool-*.jar /app/app.jar
+# Single distribution archive: ADD auto-extracts a local tar.gz, yielding /app/app.jar + /app/lib/.
+# Bundling (not shading) keeps each dependency a separate jar, so the Azure SDK's ServiceLoader-based
+# HTTP client / serializer discovery and the signed Azure jars are unaffected. The app jar's manifest
+# Class-Path resolves lib/ relative to itself. DIST_ARCHIVE defaults to the local build; CI overrides it.
+ARG DIST_ARCHIVE=target/ai-document-migration-tool-*-dist.tar.gz
+ADD ${DIST_ARCHIVE} /app/
 
 USER appuser
 

--- a/ai-document-migration-tool/README.md
+++ b/ai-document-migration-tool/README.md
@@ -146,21 +146,30 @@ with no application change. Re-runs are safe — uploads are idempotent upserts 
 ## Running as a container
 
 For running in Azure (e.g. an in-region Container Apps Job) or any clean host, the module ships a
-`Dockerfile`. It is **runtime-only**: build the runnable artifacts on a host that can reach the Maven
-repositories, then package them into a lean `eclipse-temurin:21-jre` image (no Azure CLI, no secrets).
+`Dockerfile`. It is **runtime-only**: the artefact is built on a host that can reach the Maven repositories (or
+in CI), and the image just unpacks it into a lean `eclipse-temurin:21-jre` image (no Azure CLI, no secrets).
 
-The build produces a thin jar plus a `lib/` of dependency jars (via `maven-jar-plugin` +
-`maven-dependency-plugin`) rather than a shaded uber-jar — keeping each dependency separate preserves its
-`META-INF/services`, so the Azure SDK's `ServiceLoader`-based HTTP-client and credential discovery works
-with no service-file merging.
+The build produces a **single distribution archive** —
+`ai-document-migration-tool-<version>-dist.tar.gz` (the thin app jar as `app.jar` + a `lib/` of dependency
+jars), assembled by `maven-assembly-plugin`. We bundle rather than build a shaded uber-jar: keeping each
+dependency a separate jar preserves its `META-INF/services` (so the Azure SDK's `ServiceLoader`-based
+HTTP-client / serializer discovery works) **and** the signed Azure jars keep valid signatures — a merged jar
+would collide the service files and break the signatures. The Dockerfile consumes this one archive with a
+single `ADD` (Docker auto-extracts a local tar) → `/app/app.jar` + `/app/lib/`.
 
 The image `ENTRYPOINT` is `java -jar app.jar`, i.e. the `MigrationTool` dispatcher — so the container takes the
 **same arguments as the mvn invocation**: the tool name (`index` / `table`) first, then that tool's arguments.
 
 ```bash
-# 1. build artifacts on the host, then the image (build context = this module dir)
+# 1a. LOCAL: build the dist archive, then the image (build context = this module dir; default DIST_ARCHIVE
+#     points at target/)
 mvn -pl ai-document-migration-tool -am -DskipTests package
 docker build -f ai-document-migration-tool/Dockerfile -t ai-rag-migration:1 ai-document-migration-tool
+
+# 1b. CI: pull the dist archive from Artifactory into the build context, then point DIST_ARCHIVE at it
+docker build -f ai-document-migration-tool/Dockerfile -t ai-rag-migration:1 \
+  --build-arg DIST_ARCHIVE=ai-document-migration-tool-<version>-dist.tar.gz \
+  <context-dir-containing-the-archive>
 
 # 2. run the index migration — note the leading "index" tool name
 docker run --rm --env-file sp.env ai-rag-migration:1 \

--- a/ai-document-migration-tool/pom.xml
+++ b/ai-document-migration-tool/pom.xml
@@ -19,6 +19,7 @@
         <exec.maven.plugin.version>3.1.0</exec.maven.plugin.version>
         <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
         <maven.dependency.plugin.version>3.7.0</maven.dependency.plugin.version>
+        <maven.assembly.plugin.version>3.7.1</maven.assembly.plugin.version>
         <migration.mainClass>uk.gov.moj.cp.migration.MigrationTool</migration.mainClass>
     </properties>
 
@@ -63,14 +64,13 @@
                 </configuration>
             </plugin>
 
-            <!-- Package a runnable thin jar + a lib/ directory of dependencies (rather than a shaded
-                 uber-jar). The module is run standalone in a container.  This layout deliberately
-                 keeps every dependency as its own jar, so each one retains its own META-INF/services
-                 entries — the Azure SDK discovers its Netty HTTP client, JSON serializer providers
-                 and DefaultAzureCredential token sources via ServiceLoader, and a flat classpath needs
-                 no service-file merging (which an uber-jar would). The jar-plugin writes Main-Class +
-                 a lib/-relative Class-Path into the manifest so `java -jar app.jar` just works;
-                 dependency-plugin populates lib/. -->
+            <!-- Package a runnable thin jar whose manifest carries Main-Class + a lib/-relative Class-Path,
+                 alongside a lib/ directory of the dependency jars (populated by dependency-plugin below).
+                 We deliberately keep every dependency as its own jar (rather than a shaded uber-jar): each
+                 retains its own META-INF/services — the Azure SDK discovers its Netty HTTP client and JSON
+                 serializer providers via ServiceLoader — and the signed Azure jars keep valid signatures.
+                 The thin jar + lib/ are then bundled into a single dist tar.gz (assembly-plugin below) for
+                 transport to Artifactory and the container. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -93,13 +93,39 @@
                 <executions>
                     <execution>
                         <id>copy-runtime-dependencies</id>
-                        <phase>package</phase>
+                        <!-- prepare-package: lib/ must exist before the assembly (package) bundles it. -->
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
                             <includeScope>runtime</includeScope>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Bundle the thin jar (renamed to app.jar) + lib/ into a single dist tar.gz, attached as the
+                 'dist'-classifier artefact (ai-document-migration-tool-<version>-dist.tar.gz). This is the
+                 single artefact published to Artifactory and pulled by CI; the Dockerfile auto-extracts it
+                 with one ADD. Descriptor: src/main/assembly/dist.xml. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven.assembly.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>dist</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <appendAssemblyId>true</appendAssemblyId>
+                            <descriptors>
+                                <descriptor>src/main/assembly/dist.xml</descriptor>
+                            </descriptors>
                         </configuration>
                     </execution>
                 </executions>

--- a/ai-document-migration-tool/src/main/assembly/dist.xml
+++ b/ai-document-migration-tool/src/main/assembly/dist.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Distribution archive for the migration tool: a single tar.gz bundling the thin application jar (renamed
+     to a stable app.jar) plus its dependency jars under lib/. This is the artefact published to Artifactory
+     and consumed by the Dockerfile in a single auto-extracting ADD.
+
+     We bundle (not shade) deliberately: keeping every dependency a separate jar preserves each one's
+     META-INF/services (Azure SDK ServiceLoader discovery) and its original signature — merging into an uber
+     jar would collide service files and invalidate the signed Azure jars. The app jar's manifest Class-Path
+     uses lib/-relative entries, so renaming the jar to app.jar does not affect dependency resolution. -->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>dist</id>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <files>
+        <file>
+            <source>${project.build.directory}/${project.build.finalName}.jar</source>
+            <outputDirectory>/</outputDirectory>
+            <destName>app.jar</destName>
+        </file>
+    </files>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/lib</directory>
+            <outputDirectory>lib</outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>


### PR DESCRIPTION
## What & why

The migration tool's container image was built from a **thin jar + a `lib/` of 80 separate dependency jars**, copied in **two** Docker `COPY` steps. CI is moving to **pull the built artefact from Artifactory** rather than build it locally — so `target/lib` won't exist there, and we want **one artefact + one copy step**.

This bundles the existing thin jar + `lib/` into a **single distribution archive** (`ai-document-migration-tool-<version>-dist.tar.gz`) via `maven-assembly-plugin`, attached as the `dist`-classifier artefact. The Dockerfile consumes it with a single `ADD` (Docker auto-extracts a local tar).

## Why bundle, not shade (fat jar)

Deliberately **not** an uber-jar. The Azure SDK relies on per-jar `META-INF/services` (ServiceLoader: HTTP client, serializers) and ships **10 signed jars**; merging into one jar would collide the service files and invalidate the signatures (`SecurityException` at startup). Bundling keeps each dependency a separate, signature-intact jar on a flat classpath — exactly how this repo's **function modules** already package (assembly + `copy-dependencies`).

## Changes

- **New** `src/main/assembly/dist.xml` — `tar.gz` of `app.jar` (the thin jar, renamed for a stable `ENTRYPOINT`) + `lib/*.jar`.
- **`pom.xml`** — add `maven-assembly-plugin` (`dist` classifier); move `copy-dependencies` to `prepare-package`; keep the thin-jar manifest (`Main-Class` + `lib/`-relative `Class-Path`). No shading.
- **`Dockerfile`** — two `COPY`s → one `ADD ${DIST_ARCHIVE} /app/`; `DIST_ARCHIVE` build-arg defaults to the local `target/` build and is overridden in CI with the Artifactory-downloaded path. `ENTRYPOINT` unchanged.
- **`README.md`** — container section rewritten for the single-archive build (local + CI flows).

No application source changes.

## Testing

- `mvn -pl ai-document-migration-tool -am clean package` → `…-dist.tar.gz` (67 MB) = `app.jar` + 80 `lib/` jars.
- Archive integrity: `app.jar` manifest `Main-Class`/`Class-Path` correct; a bundled signed jar (`azure-core`) **still carries `MSFTSIG.SF/.RSA`** (nothing repackaged).
- **Docker:** image builds (wildcard `ADD` auto-extracts → `/app/app.jar` + `/app/lib/` with 80 jars); `docker run … --help`, no-args (fails with usage), and `table onlyone` (dispatcher → table arg-check) all behave correctly.
- **54 unit tests** green.