### PR TITLE
Bump low/medium-risk dependencies (Renovate batches 1 & 2)

### DIFF
--- a/ai-document-answer-retrieval-function/pom.xml
+++ b/ai-document-answer-retrieval-function/pom.xml
@@ -141,7 +141,7 @@
                     <dependency>
                         <groupId>com.microsoft.azure.functions</groupId>
                         <artifactId>azure-functions-java-library</artifactId>
-                        <version>3.1.0</version>
+                        <version>${azure.functions.java.library.version}</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/ai-document-ingestion-function/pom.xml
+++ b/ai-document-ingestion-function/pom.xml
@@ -165,7 +165,7 @@
                     <dependency>
                         <groupId>com.microsoft.azure.functions</groupId>
                         <artifactId>azure-functions-java-library</artifactId>
-                        <version>3.1.0</version>
+                        <version>${azure.functions.java.library.version}</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/ai-document-metadata-check-function/pom.xml
+++ b/ai-document-metadata-check-function/pom.xml
@@ -142,7 +142,7 @@
                     <dependency>
                         <groupId>com.microsoft.azure.functions</groupId>
                         <artifactId>azure-functions-java-library</artifactId>
-                        <version>3.1.0</version>
+                        <version>${azure.functions.java.library.version}</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/ai-document-migration-tool/pom.xml
+++ b/ai-document-migration-tool/pom.xml
@@ -16,10 +16,10 @@
     </description>
 
     <properties>
-        <exec.maven.plugin.version>3.1.0</exec.maven.plugin.version>
+        <exec.maven.plugin.version>3.6.3</exec.maven.plugin.version>
         <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
-        <maven.dependency.plugin.version>3.7.0</maven.dependency.plugin.version>
-        <maven.assembly.plugin.version>3.7.1</maven.assembly.plugin.version>
+        <maven.dependency.plugin.version>3.11.0</maven.dependency.plugin.version>
+        <maven.assembly.plugin.version>3.8.0</maven.assembly.plugin.version>
         <migration.mainClass>uk.gov.moj.cp.migration.MigrationTool</migration.mainClass>
     </properties>
 

--- a/ai-document-migration-tool/pom.xml
+++ b/ai-document-migration-tool/pom.xml
@@ -16,9 +16,7 @@
     </description>
 
     <properties>
-        <exec.maven.plugin.version>3.6.3</exec.maven.plugin.version>
-        <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
-        <maven.dependency.plugin.version>3.11.0</maven.dependency.plugin.version>
+        <!-- exec/jar/dependency plugin versions are inherited from the root pom -->
         <maven.assembly.plugin.version>3.8.0</maven.assembly.plugin.version>
         <migration.mainClass>uk.gov.moj.cp.migration.MigrationTool</migration.mainClass>
     </properties>

--- a/ai-document-shared-artefacts/pom.xml
+++ b/ai-document-shared-artefacts/pom.xml
@@ -74,13 +74,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.21.1</version>
+            <version>2.22.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-assertj3</artifactId>
-            <version>2.11.0</version>
+            <version>2.12.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -118,7 +118,7 @@
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>7.20.0</version>
+                <version>7.23.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -166,7 +166,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <id>add-generated-source</id>

--- a/ai-document-status-check-function/pom.xml
+++ b/ai-document-status-check-function/pom.xml
@@ -138,7 +138,7 @@
                     <dependency>
                         <groupId>com.microsoft.azure.functions</groupId>
                         <artifactId>azure-functions-java-library</artifactId>
-                        <version>3.1.0</version>
+                        <version>${azure.functions.java.library.version}</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/ai-document-system-prompt-harness-eval/pom.xml
+++ b/ai-document-system-prompt-harness-eval/pom.xml
@@ -18,9 +18,7 @@
     </description>
 
     <properties>
-        <exec.maven.plugin.version>3.6.3</exec.maven.plugin.version>
-        <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
-        <maven.dependency.plugin.version>3.11.0</maven.dependency.plugin.version>
+        <!-- exec/jar/dependency plugin versions are inherited from the root pom -->
         <harness.mainClass>uk.gov.moj.cp.harness.TestHarness</harness.mainClass>
         <!-- This is a non-deployed, on-demand evaluation tool whose value is in running it live
              (orchestration over real LLM calls), not in unit-testable logic. Waive Sonar's

--- a/ai-document-system-prompt-harness-eval/pom.xml
+++ b/ai-document-system-prompt-harness-eval/pom.xml
@@ -18,9 +18,9 @@
     </description>
 
     <properties>
-        <exec.maven.plugin.version>3.1.0</exec.maven.plugin.version>
+        <exec.maven.plugin.version>3.6.3</exec.maven.plugin.version>
         <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
-        <maven.dependency.plugin.version>3.7.0</maven.dependency.plugin.version>
+        <maven.dependency.plugin.version>3.11.0</maven.dependency.plugin.version>
         <harness.mainClass>uk.gov.moj.cp.harness.TestHarness</harness.mainClass>
         <!-- This is a non-deployed, on-demand evaluation tool whose value is in running it live
              (orchestration over real LLM calls), not in unit-testable logic. Waive Sonar's

--- a/ai-service-orchestration-test/pom.xml
+++ b/ai-service-orchestration-test/pom.xml
@@ -26,28 +26,28 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>5.3.0</version>
+            <version>5.5.7</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy</artifactId>
-            <version>3.0.17</version>
+            <version>3.0.25</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.21.3</version>
+            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>2.0.2</version>
+            <version>2.0.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,12 @@
             ${project.reporting.outputDirectory}/jacoco/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <plugins.jacoco.version>0.8.15</plugins.jacoco.version>
+
+        <!-- Build-plugin versions shared by the non-deployed tooling modules
+             (ai-document-migration-tool, ai-document-system-prompt-harness-eval) -->
+        <exec.maven.plugin.version>3.6.3</exec.maven.plugin.version>
+        <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
+        <maven.dependency.plugin.version>3.11.0</maven.dependency.plugin.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -27,19 +27,19 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <azure.functions.maven.plugin.version>1.24.0</azure.functions.maven.plugin.version>
-        <azure.functions.java.library.version>3.2.3</azure.functions.java.library.version>
+        <azure.functions.maven.plugin.version>1.42.0</azure.functions.maven.plugin.version>
+        <azure.functions.java.library.version>3.3.0</azure.functions.java.library.version>
         <plugins.maven.jgitflow.version>1.0-m5.1</plugins.maven.jgitflow.version>
         <azure.openai.version>1.0.0-beta.16</azure.openai.version>
-        <openai-java.version>4.38.0</openai-java.version>
-        <junit-jupiter-engine.version>6.0.2</junit-jupiter-engine.version>
-        <mockito-junit-jupiter.version>5.21.0</mockito-junit-jupiter.version>
+        <openai-java.version>4.41.0</openai-java.version>
+        <junit-jupiter-engine.version>6.1.1</junit-jupiter-engine.version>
+        <mockito-junit-jupiter.version>5.23.0</mockito-junit-jupiter.version>
         <assertj-core.version>3.27.7</assertj-core.version>
         <langchain4j.version>0.30.0</langchain4j.version>
         <jackson.version>2.15.2</jackson.version>
-        <opentelemetry-sdk.version>1.58.0</opentelemetry-sdk.version>
+        <opentelemetry-sdk.version>1.31.0</opentelemetry-sdk.version>
         <api-cp-ai-rag.version>0.0.12</api-cp-ai-rag.version>
-        <hibernate-validator.version>9.0.1.Final</hibernate-validator.version>
+        <hibernate-validator.version>9.1.1.Final</hibernate-validator.version>
         <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
 
         <!-- SonarQube Properties -->
@@ -49,7 +49,7 @@
         <sonar.coverage.jacoco.xmlReportPaths>
             ${project.reporting.outputDirectory}/jacoco/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
-        <plugins.jacoco.version>0.8.14</plugins.jacoco.version>
+        <plugins.jacoco.version>0.8.15</plugins.jacoco.version>
     </properties>
 
     <build>
@@ -84,12 +84,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.5.6</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.5.6</version>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
@@ -127,7 +127,7 @@
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-bom</artifactId>
-                <version>1.31.0</version>
+                <version>${opentelemetry-sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -176,7 +176,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
-                <version>2.25.2</version>
+                <version>2.26.0</version>
             </dependency>
 
             <!-- Testing dependencies -->


### PR DESCRIPTION
Applies the safe build-plugin, test-library and runtime dependency updates from the Renovate dependency dashboard (#1), plus two pre-existing version-drift fixes. `mvn clean verify` passes across all modules.

## Batch 1 — build plugins & test libs
- jacoco `0.8.14`→`0.8.15`, surefire/failsafe `3.1.2`→`3.5.6`
- azure-functions-maven-plugin `1.24.0`→`1.42.0`
- openapi-generator `7.20.0`→`7.23.0`, build-helper `3.0.0`→`3.6.1`
- junit `6.0.2`→`6.1.1`, mockito `5.21.0`→`5.23.0`, xmlunit `2.11.0`→`2.12.0`
- groovy `3.0.17`→`3.0.25`, testcontainers `2.0.2`→`2.0.5` + junit-jupiter `1.21.3`→`1.21.4`
- rest-assured `5.3.0`→`5.5.7` (safe minor)
- exec `3.1.0`→`3.6.3`, dependency-plugin `3.7.0`→`3.11.0`, assembly `3.7.1`→`3.8.0`

## Batch 2 — runtime deps
- azure-functions-java-library `3.2.3`→`3.3.0`
- openai-java `4.38.0`→`4.41.0`, hibernate-validator `9.0.1`→`9.1.1.Final`
- log4j-slf4j-impl `2.25.2`→`2.26.0`, jackson-datatype-jsr310 `2.21.1`→`2.22.0`

## Drift cleanup
- The four hardcoded `azure-functions-java-library 3.1.0` plugin overrides in the function modules now reference the managed `${azure.functions.java.library.version}` property, so they can't drift from the compile version again.
- The `opentelemetry-bom` import was a literal `1.31.0` sitting next to an unused `1.58.0` property; it now references the property (single source of truth).

## Deferred (NOT in this PR — breaking, need separate PRs with code migration)
- **azure-sdk-bom `1.3.7`** redesigns `azure-search-documents` (removes `SearchDocument`, the `com.azure.search.documents.util` package, and the `search(String, SearchOptions, Context)` overload) — held at `1.3.2`. `opentelemetry-bom` held at `1.31.0` per its in-POM coupling comment, to bump together with the Search SDK migration.
- langchain4j `0.30`→`1.17` (chunking/embedding API changes), slf4j `1.x`→`2.0` (needs `log4j-slf4j-impl`→`log4j-slf4j2-impl`), rest-assured `6.0` (test-only major).
- Manual-only (Renovate can't resolve): `api-cp-ai-rag` contract package and the `eclipse-temurin:21-jre` ACR-mirrored base image.

## Testing
`mvn clean verify` — green across all modules (~330 unit tests). Integration-test module (`ai-service-orchestration-test`) test-compiles cleanly under the `ai-rag-integration-test` profile with the bumped rest-assured/groovy/testcontainers.