### PR TITLE
Bump azure-sdk-bom to 1.3.7, pin azure-search-documents at 11.8.0 (Renovate batch 4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <assertj-core.version>3.27.7</assertj-core.version>
         <langchain4j.version>1.17.0</langchain4j.version>
         <jackson.version>2.15.2</jackson.version>
-        <opentelemetry-sdk.version>1.31.0</opentelemetry-sdk.version>
+        <opentelemetry-sdk.version>1.49.0</opentelemetry-sdk.version>
         <api-cp-ai-rag.version>0.0.12</api-cp-ai-rag.version>
         <hibernate-validator.version>9.1.1.Final</hibernate-validator.version>
         <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
@@ -125,9 +125,18 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.3.2</version>
+                <version>1.3.7</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- Pin azure-search-documents to 11.8.0: azure-sdk-bom 1.3.7 manages 12.0.0, a breaking
+                 redesign (SearchDocument / SearchResult.getDocument / uploadDocuments all removed).
+                 Held on the 11.x line to avoid that rewrite; the 11->12 migration is a separate,
+                 integration-tested change. Resolves fine against the BOM's newer azure-core. -->
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-search-documents</artifactId>
+                <version>11.8.0</version>
             </dependency>
             <!-- Keep the telemetry dependency in sync wth azure SDK bom version-->
             <dependency>


### PR DESCRIPTION
## What & why

Renovate's Dependency Dashboard offers `azure-sdk-bom` 1.3.2 → **1.3.7**. That BOM pins `azure-search-documents` straight to **12.0.0**, a breaking redesign of the document model (`SearchDocument`, `SearchResult.getDocument(Class)`, `uploadDocuments`/`mergeDocuments` all removed; query text moves onto `SearchOptions`; `VectorSearchOptions` gone; `SearchPagedIterable` relocated). Adopting it would mean a wholesale rewrite of the ingestion, retrieval and migration-tool code.

This PR takes the SDK bump but **pins `azure-search-documents` at 11.8.0** to stay on the proven 11.x API and avoid that rewrite. The 11→12 migration is deferred to its own integration-tested change.

## Changes (root `pom.xml` only)

- `azure-sdk-bom` 1.3.2 → **1.3.7** (modernises azure-core 1.55.x → 1.58.0, azure-identity/storage/etc.)
- Explicit `dependencyManagement` pin: `azure-search-documents` **11.8.0** (overrides the BOM's 12.0.0)
- `opentelemetry-sdk.version` 1.31.0 → **1.49.0** — coupled: `azure-monitor-opentelemetry-autoconfigure` becomes 1.4.0 under the new BOM and is built against OTel 1.49.0 (kept in lock-step per the existing comment)

## Verification

- `mvn clean verify` passes across all modules with **no source changes** (search API surface unchanged).
- Resolved versions confirmed: `azure-search-documents` 11.8.0 on `azure-core` 1.58.0; `azure-monitor-opentelemetry-autoconfigure` 1.4.0 with `opentelemetry-sdk` 1.49.0; no version-convergence warnings.

## Follow-ups (not in this PR)

- The deferred `azure-search-documents` 11→12 redesign (its own PR).
- Renovate config migration `config:base` → `config:recommended` (separate one-liner).