### PR TITLE
Bump patch-level dependencies (Renovate)

### DIFF
--- a/ai-document-shared-artefacts/pom.xml
+++ b/ai-document-shared-artefacts/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.22.0</version>
+            <version>2.22.1</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,11 +35,11 @@
         <junit-jupiter-engine.version>6.1.1</junit-jupiter-engine.version>
         <mockito-junit-jupiter.version>5.23.0</mockito-junit-jupiter.version>
         <assertj-core.version>3.27.7</assertj-core.version>
-        <langchain4j.version>1.17.0</langchain4j.version>
+        <langchain4j.version>1.17.2</langchain4j.version>
         <jackson.version>2.15.2</jackson.version>
         <opentelemetry-sdk.version>1.49.0</opentelemetry-sdk.version>
         <api-cp-ai-rag.version>0.0.12</api-cp-ai-rag.version>
-        <hibernate-validator.version>9.1.1.Final</hibernate-validator.version>
+        <hibernate-validator.version>9.1.2.Final</hibernate-validator.version>
         <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
 
         <!-- SonarQube Properties -->
@@ -191,7 +191,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j2-impl</artifactId>
-                <version>2.26.0</version>
+                <version>2.26.1</version>
             </dependency>
 
             <!-- Testing dependencies -->


### PR DESCRIPTION
## What & why

Low-risk **patch-level** dependency bumps flagged by the Renovate Dependency Dashboard (issue #1), separate from the deferred `azure-search-documents` 11→12 work.

| Dependency | From → To |
|---|---|
| `com.fasterxml.jackson.datatype:jackson-datatype-jsr310` | 2.22.0 → **2.22.1** |
| `dev.langchain4j:langchain4j` | 1.17.0 → **1.17.2** |
| `org.apache.logging.log4j:log4j-slf4j2-impl` | 2.26.0 → **2.26.1** |
| `org.hibernate.validator:hibernate-validator` | 9.1.1.Final → **9.1.2.Final** |

## Deliberately excluded

- **`opentelemetry-bom` → 1.63.0** — left at **1.49.0**. It is intentionally kept in lock-step with `azure-monitor-opentelemetry-autoconfigure` 1.4.0 (from `azure-sdk-bom` 1.3.7), which is built against OTel 1.49.0; the standalone 1.63.0 bump would break that coupling.
- **`azure-search-documents`** (11.8.1 / 12.x) — out of scope; the 11→12 redesign is a separate integration-tested change and 11.8.0 is pinned on purpose.

## Verification

- `mvn clean verify` — all modules compile, unit tests + JaCoCo pass. No source changes (property/version-only).