### PR TITLE
Bump azure-search-documents 11.8.0 -> 11.8.1 (Renovate)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,14 +129,14 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- Pin azure-search-documents to 11.8.0: azure-sdk-bom 1.3.7 manages 12.0.0, a breaking
-                 redesign (SearchDocument / SearchResult.getDocument / uploadDocuments all removed).
-                 Held on the 11.x line to avoid that rewrite; the 11->12 migration is a separate,
-                 integration-tested change. Resolves fine against the BOM's newer azure-core. -->
+            <!-- Pin azure-search-documents to 11.8.1 (latest 11.x patch): azure-sdk-bom 1.3.7 manages
+                 12.0.0, a breaking redesign (SearchDocument / SearchResult.getDocument / uploadDocuments
+                 all removed). Held on the 11.x line to avoid that rewrite; the 11->12 migration is a
+                 separate, integration-tested change. Resolves fine against the BOM's newer azure-core. -->
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-search-documents</artifactId>
-                <version>11.8.0</version>
+                <version>11.8.1</version>
             </dependency>
             <!-- Keep the telemetry dependency in sync wth azure SDK bom version-->
             <dependency>


### PR DESCRIPTION
## What & why

Bumps `com.azure:azure-search-documents` **11.8.0 → 11.8.1**, the latest patch on the 11.x line, as flagged by the Renovate Dependency Dashboard (issue #1).

This is a **patch-level, non-breaking** change. We remain deliberately pinned on the 11.x line — the breaking redesign (`SearchDocument` / `SearchResult.getDocument` / `uploadDocuments` all removed) only lands at **12.0.0**, which stays a separate, integration-tested change. The pin comment is updated to reflect 11.8.1.

## Verification

- `mvn clean verify` — all modules compile, unit tests + JaCoCo pass (no source changes; version + comment only).
- Confirmed `azure-search-documents` resolves at 11.8.1 against the BOM's `azure-core` 1.58.0; SDK-using modules (ingestion, retrieval, migration-tool) build and test green.