### PR TITLE
docs: multi-client data isolation pipeline artefacts and ADR

### DIFF
--- a/docs/pipeline/DD-42722-multi-tenant-data-isolation/00-input-brief.md
+++ b/docs/pipeline/DD-42722-multi-tenant-data-isolation/00-input-brief.md
@@ -1,0 +1,66 @@
+# Input Brief — Multi-Client Data Isolation for CP AI RAG Service
+
+**Source:** Confluence page 1973297793 (space CROWN, "Multi-Tenant Data Isolation for CP AI RAG Service", v10) + codebase verification (2026-07-20) + stakeholder decisions (Mahesh, 2026-07-20).
+
+**Naming decision (supersedes the Confluence page):** the tenancy attribute is **`clientId`**, not `tenantId`. All schema fields, code identifiers, partition keys and telemetry dimensions use `clientId`.
+
+---
+
+## 1. Problem statement (from Confluence, corrected)
+
+The CP AI RAG Service is single-consumer by construction: APIM (`api-cp-ai-rag-secure`) validates a single Entra ID client application's JWT; the function backends receive no caller identity. All ingested documents, AI Search chunks, Table rows and blobs live in one shared namespace. Any caller in possession of a UUID (documentReference / transactionId) can read any other caller's status or answer payload.
+
+Goal: per-client data isolation —
+1. Identity at the edge: APIM (per AMP standards, design owned by another team, **not yet concrete**) identifies the consumer and passes a trusted client identifier downstream. Backends trust it because they only accept APIM traffic (function key + network restriction).
+2. Isolation in the data plane: single AI Search index, single storage account, single set of tables retained. `clientId` becomes a top-level filterable Search field, the Table partition key, a blob path prefix, a non-optional leading clause on every search filter, and a queue-payload field.
+
+Existing production corpus (single client) is migrated to a designated incumbent client ID before enforcement. Cut-over is feature-flag gated for reversibility.
+
+## 2. Verified current state (codebase, 2026-07-20)
+
+- **APIM:** `validate-azure-ad-token` against one allowed application-id; `subscriptionRequired=false`; per-operation policies inject the function key. No consumer identification.
+- **HTTP functions:** `AuthorizationLevel.FUNCTION` only. Endpoints (contract-first, spec in `api-cp-ai-rag` repo): `POST /document-upload`, `GET /document-upload/{documentReference}`, `POST /answer-user-query` (sync), `POST /answer-user-query-async`, `GET /answer-user-query-async-status/{transactionId}`.
+  - NOTE: the Confluence page references a `DocumentStatusCheckFunction` / `GET /document-status?document-name=…` endpoint — **it does not exist**. Only `DocumentStatusByReferenceFunction` exists in `ai-document-status-check-function`.
+- **AI Search:** index `ai-rag-service-index` (`vector-db-index-schema.json`) — fields `id`, `chunk`, `chunkVector`, `documentFileName`, `documentId`, `pageNumber`, `chunkIndex`, `documentFileUrl`, `customMetadata` (caller-supplied key/value collection). No client field. Chunk `id` is a **random UUID** (`DocumentChunkingService`), so no cross-client key-collision risk in the index.
+- **OData filter:** `AzureAISearchService.generateFilterExpression` builds `customMetadata/any(...)` clauses. Single-quote escaping **already exists** (`StringUtil.escapeODataStringLiteral`, doubles quotes) — the Confluence claim of an unescaped injection surface is stale. Remaining work: prepend a non-optional `clientId eq '…'` clause + regression tests.
+- **Table Storage:**
+  - `DocumentIngestionOutcome` (via `DocumentIngestionOutcomeTableService`): PartitionKey = RowKey = documentId.
+  - `GeneratedAnswer` (via `AnswerGenerationTableService`): PartitionKey = RowKey = transactionId.
+  - **`IdempotencyGuard` (shared artefacts) leases and fences on these rows** — claim/release/readForClaim all construct `TableEntity(key, key)` with lease columns `LeaseOwner`/`LeaseExpiresAt` and ETag fencing. Any partition-key change must make the whole `IdempotencyStatusStore` interface client-aware, and queue workers must recover `clientId` from the message before claiming a lease. (Not mentioned in the Confluence page at all.)
+- **Blob Storage:** flat naming `{documentId}_{yyyyMMdd}.{ext}` built centrally in `DocumentBlobNameResolver` (regex parse back to documentId). Answer payload blobs: `llm-answer-with-chunks-{transactionId}.json`, `llm-input-chunks-{transactionId}.json`.
+- **Queues/DTOs:** `QueueIngestionMetadata` (documentId, documentName, metadata, blobUrl, currentTimestamp); `AnswerGenerationQueuePayload` (transactionId, userQuery, queryPrompt, metadataFilter); `ScoringQueuePayload` (**filename only** — the actual scoring input is a `ScoringPayload` blob; the Confluence claim that the scoring worker reads tenant from the queue message needs correcting: clientId must ride the `ScoringPayload` blob and/or payload, and the scorer writes the groundedness score back to the `(clientId, transactionId)` row).
+- **Duplicate check:** `DocumentUploadFunction.isDocumentAlreadyProcessed(documentId)` — currently global.
+- **Telemetry:** `PublishScoreService` publishes `query_type` dimension = raw user query (separate PII concern); no client dimension.
+- **Citation guard / idempotency env interplay:** async retries ride queue redelivery (maxDequeueCount 3) with lease release before rethrow — client threading must survive redelivery (it does naturally if clientId is in the queue message).
+
+## 3. Stakeholder decisions (2026-07-20, override the page where they conflict)
+
+| # | Decision |
+|---|----------|
+| D1 | Attribute named **`clientId`** everywhere (field, constant, partition key, telemetry dimension, blob prefix). |
+| D2 | `documentId` uniqueness is **per client**: dedup check, overwrite path and chunk deletion scoped to `(clientId, documentId)`. Two clients may use the same documentId. |
+| D3 | Cut-over: **queues drained first** — no in-flight messages at cut-over, so no intermediate-state data and no dual-write mode. Migration tool stamps clientId on all existing AI Search documents and Table rows before the enforcement flag flips. |
+| D4 | AMP consumer-identity design is not concrete. **Assume** APIM identifies the consumer upstream and the identity reaches the function app in a recognised header (may become JWT/cookie later). **Encapsulate client-ID extraction in one abstract shared method** in `ai-document-shared-artefacts`, referenced by every HTTP-triggered function — a single point of change when AMP finalises. |
+| D5 | The injected header is an **internal contract between APIM policy and function apps** — not part of the consumer-facing OpenAPI spec. HTTP functions return **401** when the identity is missing/invalid. |
+| D6 | Eval harness (`ai-document-system-prompt-harness-eval`) impact: open — design should propose the simplest approach that keeps it working against a client-scoped index. |
+| D7 | `clientId` format: **UUID assumed for now** (user to confirm; format constraint must be validated at the boundary since the value lands in OData literals, partition keys, blob paths, metric dimensions). |
+
+## 4. Design elements retained from the Confluence page
+
+- Top-level `clientId` field in the Search index (filterable, not searchable) — preferred over reusing caller-controlled `customMetadata` (trust-boundary separation).
+- Table keying: `DocumentIngestionOutcome` → PK=clientId, RK=documentId; `GeneratedAnswer` → PK=clientId, RK=transactionId; clientId also persisted as a non-key column. Cross-client lookups return **404 (not 403)** to avoid existence leakage.
+- Blob paths: new blobs at `c={clientId}/{documentId}_{yyyyMMdd}.{ext}` (and same prefix for answer-payload blobs); legacy blobs stay in place; blob-trigger supports both shapes transitionally; the Table row (not the path) is the authoritative ownership record.
+- Queue payloads gain non-optional `clientId`.
+- Telemetry gains a `client_id` dimension (per-client groundedness segmentation).
+- Feature flag (e.g. `CLIENT_FILTERING_ENABLED`) gates enforcement; off = identity optional, filter omitted (rollback safety net).
+- Logical isolation chosen over index-per-client / full silo, but clientId treated as a namespace so a client can later be migrated to its own index/silo via routing config only.
+- Migration: add nullable field to live index → backfill chunks via mergeOrUpload (progress: `clientId eq null` count → 0) → Table rows copy-then-delete (idempotent, resumable; must skip/handle rows with live idempotency leases — prefer migrating only terminal rows after queue drain) → blobs left in place → flag flip per environment → onboard next client via APIM config only.
+- Recommended hardening (scope decision pending): reject `metadataFilter` keys not on an allow-list so callers cannot filter on internal fields.
+
+## 5. Out of scope
+
+- APIM policy implementation (`cpp-azure-api-management` repo) — tracked as a coordination dependency; our side defines the internal header contract and enforcement behind the abstraction (D4).
+- Per-client rate limits/quotas/analytics (AMP standards, later).
+- Physical migration of legacy blobs; retirement of the dual-path resolver.
+- Per-client index/silo migration runbook.
+- `query_type` PII telemetry fix (flagged separately; adjacent but independent).

--- a/docs/pipeline/DD-42722-multi-tenant-data-isolation/01-requirements.md
+++ b/docs/pipeline/DD-42722-multi-tenant-data-isolation/01-requirements.md
@@ -1,0 +1,125 @@
+# Requirements: Multi-Client Data Isolation (CP AI RAG Service)
+
+## Context
+The CP AI RAG Service is single-consumer by construction: APIM validates one Entra ID
+application's JWT and the function backends receive no caller identity, so all documents,
+AI Search chunks, Table rows and blobs share one namespace. Any caller holding a UUID
+(`documentReference` / `transactionId`) can read any other caller's status or answer payload.
+This initiative introduces per-client logical isolation across the data plane using a single
+`clientId` attribute (see input brief §1–§4, decisions D1–D7). The existing production corpus
+is migrated to a designated incumbent `clientId` before enforcement, which is feature-flag
+gated for reversibility. Source of truth:
+`docs/pipeline/DD-42722-multi-tenant-data-isolation/00-input-brief.md`.
+
+Not applicable from the generic template: CQRS command/query separation and Spring Boot layering
+— this is a multi-module Maven Azure Functions (Java) service.
+
+## Actors
+| Actor | Description |
+|-------|-------------|
+| Consuming client application | Entra ID app calling the API via APIM; identified upstream and carried downstream as `clientId`. Multiple clients post-onboarding. |
+| APIM policy (edge) | Validates the caller and injects the trusted internal client-identity header. Design owned by another team (`cpp-azure-api-management`); not yet concrete (D4). |
+| HTTP/Queue/Blob functions | Trust APIM-injected identity (function key + network restriction), enforce isolation in the data plane. |
+| Platform/release operator | Runs migration/backfill tooling and flips the enforcement flag per environment. |
+| Answer-scoring / telemetry consumer | Reads per-client groundedness segmentation via the `client_id` metric dimension. |
+
+## Functional requirements
+| ID | Requirement                                                                                                                                                                                                                                                                                                                                                             | Priority |
+|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| FR-1 | Provide a single abstract, shared client-identity extraction method in `ai-document-shared-artefacts`, referenced by every HTTP-triggered function, that reads `clientId` from the internal APIM-injected header (D4). It is the single point of change when AMP finalises the identity mechanism.                                                                      | Must |
+| FR-2 | When enforcement is enabled, any HTTP request with a missing or invalid client identity is rejected with **401** (D5). No downstream processing occurs.                                                                                                                                                                                                                 | Must |
+| FR-3 | Gate all isolation enforcement behind a feature flag (e.g. `CLIENT_FILTERING_ENABLED`). Flag off = identity optional and filter clause omitted (pre-existing behaviour); flag on = identity mandatory and filter applied.                                                                                                                                               | Must |
+| FR-4 | Add a top-level `clientId` field to the AI Search index (`vector-db-index-schema-v2.json`): filterable, not searchable, distinct from caller-controlled `customMetadata` (trust-boundary separation).                                                                                                                                                                   | Must |
+| FR-5 | `AzureAISearchService.generateFilterExpression` must prepend a non-optional leading `clientId eq '<clientId>'` clause to every search filter when enforcement is on. Existing single-quote escaping (`StringUtil.escapeODataStringLiteral`) is retained; no client value reaches an OData literal unescaped.                                                            | Must |
+| FR-6 | Re-key Table Storage for per-client partitioning: `DocumentIngestionOutcome` → PK=`clientId`, RK=`documentId`; `GeneratedAnswer` → PK=`clientId`, RK=`transactionId`; `clientId` also stored as a non-key column.                                                                                                                                                       | Must |
+| FR-7 | Make `IdempotencyStatusStore` / `IdempotencyGuard` client-aware: lease claim, release, fence (ETag/If-Match) and `readForClaim` operate on `(clientId, documentId)` / `(clientId, transactionId)` rows. Queue workers must recover `clientId` from the message before claiming a lease.                                                                                 | Must |
+| FR-8 | Scope `documentId` uniqueness to `(clientId, documentId)` (D2): the dedup check (`DocumentUploadFunction.isDocumentAlreadyProcessed`), overwrite path and chunk deletion are all client-scoped. Two clients may reuse the same `documentId` without collision.                                                                                                          | Must |
+| FR-9 | Prefix new blob paths with the client namespace: `c={clientId}/{documentId}_{yyyyMMdd}.{ext}` for uploaded documents and the same prefix for answer-payload blobs (`llm-answer-with-chunks-*`, `llm-input-chunks-*`). Path construction stays centralised in `DocumentBlobNameResolver`.                                                                                | Must |
+| FR-10 | Provide dual-path resolution: the blob trigger and name resolver recognise both the new prefixed shape and the legacy flat `{documentId}_{yyyyMMdd}.{ext}` shape. The Table row (not the path) is the authoritative ownership record.                                                                                                                                   | Must |
+| FR-11 | Thread a non-optional `clientId` through queue payloads: `QueueIngestionMetadata` and `AnswerGenerationQueuePayload` gain a `clientId` field so it survives redelivery (maxDequeueCount 3) on the async/citation-guard retry path.                                                                                                                                      | Must |
+| FR-12 | Carry `clientId` to the scoring worker via the `ScoringPayload` blob and/or payload, **not** solely `ScoringQueuePayload` (which is filename-only). The scorer writes the groundedness score back to the correct `(clientId, transactionId)` row.                                                                                                                       | Must |
+| FR-13 | Add a `client_id` dimension to telemetry published by `PublishScoreService`, enabling per-client groundedness segmentation. (Independent of the separate `query_type` PII concern.)                                                                                                                                                                                     | Must |
+| FR-14 | Cross-client lookups (a `documentReference`/`transactionId` belonging to another client) return **404**, never 403, to avoid existence leakage.                                                                                                                                                                                                                         | Must |
+| FR-15 | Provide migration/backfill tooling: add nullable `clientId` to the live index → backfill chunks via `mergeOrUpload` (progress measured by `clientId eq null` count → 0) → copy-then-delete Table rows (idempotent, resumable) → leave blobs in place. Rows with live idempotency leases must be skipped/handled; prefer migrating only terminal rows after queue drain. | Must |
+| FR-16 | Support cut-over with drained queues (D3): no in-flight messages at cut-over, so no dual-write mode and no intermediate-state records. The migration tool stamps `clientId` on all existing Search documents and Table rows before the enforcement flag flips per environment.                                                                                          | Must |
+| FR-17 | **[Scope-pending]** Optionally reject `metadataFilter` keys not on an allow-list so callers cannot filter on internal fields (e.g. `clientId`). In/out of scope for this iteration is an open question (OQ-2).                                                                                                                                                          | Should |
+| FR-18 | **[Open]** Keep the eval harness (`ai-document-system-prompt-harness-eval`) working against a client-scoped index (D6). Approach to be proposed at design stage (OQ-3).                                                                                                                                                                                                 | Should |
+
+## Non-functional requirements
+| ID | Category | Requirement | Threshold |
+|----|----------|-------------|-----------|
+| NFR-1 | Infrastructure | No new Azure resources: single AI Search index, single storage account, single set of tables retained. Isolation is logical only. | Zero new infra resources |
+| NFR-2 | Reversibility | Enforcement fully reversible by flipping `CLIENT_FILTERING_ENABLED` off, with no data rewrite required to roll back. | Flag toggle only |
+| NFR-3 | Confidentiality | No cross-client existence leakage: responses must not reveal whether another client's resource exists (drives 404-not-403 semantics). | Zero existence leakage |
+| NFR-4 | Input validation | `clientId` format validated at the boundary before it is used in OData literals, partition keys, blob paths or metric dimensions. UUID format assumed (D7). Malformed values rejected (401). | 100% of ingress paths |
+| NFR-5 | Backward compatibility | Legacy flat-path blobs remain readable; dual-path resolver must not break existing document retrieval. | No regression on legacy blobs |
+| NFR-6 | Idempotency | Existing idempotency guarantees (lease TTL, ETag fencing, redelivery skip of terminal rows) preserved under client-aware keying; no duplicate LLM/embedding work or scoring re-enqueue introduced. | No idempotency regression |
+| NFR-7 | Contract stability | The internal client-identity header is NOT added to the consumer-facing OpenAPI spec (`api-cp-ai-rag`); the public contract is unchanged (D5). | Consumer spec unchanged |
+
+## Acceptance criteria
+
+### FR-1 / FR-2 — client-identity extraction & 401
+- AC-1: Given enforcement is on and a valid client-identity header, when any HTTP endpoint is called, then the extracted `clientId` is available to the handler and the request proceeds (positive path).
+- AC-2: Given enforcement is on and the client-identity header is absent, when any HTTP endpoint is called, then the response is **401** and no downstream processing occurs (header absence 401).
+- AC-3: Given a caller attempts to override/spoof the identity via a request body or `metadataFilter`, when the request is processed, then only the APIM-injected header value is used; the spoofed value has no effect (header spoof override).
+
+### FR-3 — feature flag
+- AC-4: Given `CLIENT_FILTERING_ENABLED=false`, when a request arrives without identity, then it is processed as before (identity optional, no `clientId` filter clause).
+
+### FR-4 / FR-5 — index field & filter injection
+- AC-5: Unit test on `generateFilterExpression`: given a `clientId` and any `metadataFilter`, then the produced OData string begins with a non-optional `clientId eq '<escaped>'` clause ANDed with the rest (filter unit test).
+- AC-6: Regression test: a client's query never returns chunks stamped with a different `clientId` (filter injection regression).
+
+### FR-6 / FR-7 / FR-8 — partitioning, idempotency, per-client documentId
+- AC-7: Given two clients ingest the same `documentId`, then both rows coexist under distinct partition keys and neither dedup, overwrite nor chunk-deletion of one affects the other.
+- AC-8: Given a duplicate queue delivery for an already-terminal `(clientId, documentId)`/`(clientId, transactionId)` row, then the worker skips the expensive pipeline (no LLM/embedding call, no scoring re-enqueue) — idempotency preserved under client-aware keys.
+
+### FR-9 / FR-10 — blob prefixing & dual-path
+- AC-9: Given enforcement is on, when a document is uploaded, then its blob is written under `c={clientId}/…` and answer-payload blobs use the same prefix.
+- AC-10: Given a legacy flat-path blob, when it is triggered/resolved, then the resolver parses it correctly and ownership is taken from the Table row.
+
+### FR-11 / FR-12 — queue & scoring threading
+- AC-11: Given an async answer request, when it rides queue redelivery up to `maxDequeueCount`, then `clientId` is present on every redelivery and the lease is claimed on the correct client-scoped row.
+- AC-12: Given a scoring message, when the scorer runs, then it reads `clientId` from the `ScoringPayload` (not the filename-only queue message) and writes the groundedness score back to the `(clientId, transactionId)` row.
+
+### FR-13 — telemetry
+- AC-13: Given scores from two clients, when telemetry is published, then metrics carry a `client_id` dimension and can be segmented per client (telemetry segmentation).
+
+### FR-14 — cross-client 404
+- AC-14: Given client B requests a `documentReference`/`transactionId` owned by client A, then the response is **404** (not 403, not 200), leaking no existence signal (cross-client 404).
+
+### FR-15 / FR-16 — migration & cut-over
+- AC-15: Given the backfill tool runs on the live index, then all pre-existing chunks and Table rows are stamped with the incumbent `clientId`, the `clientId eq null` count reaches 0, and the tool is resumable and skips rows under live leases.
+- AC-16: Given queues are drained before cut-over, then no in-flight message exists at flag flip and no intermediate-state/dual-write record is produced.
+
+## Constraints
+- **Contract-first (D5, CLAUDE.md):** the internal client-identity header is an APIM↔function-app contract only and must not appear in the consumer OpenAPI spec (`api-cp-ai-rag`). Any consumer-facing shape change must go through the spec repo first.
+- **Managed identity only** (`.claude/context/azure-functions.md`): no new connection strings/keys; SDK clients use `DefaultAzureCredential`.
+- **No new infra** (NFR-1): logical isolation, single index/account/tables.
+- **Count-variable invariants** and existing retrieval-refinement pipeline behaviour must be preserved when the filter clause is added.
+- **AMP standards:** upstream consumer-identity design is owned by another team and not yet concrete (D4).
+
+## Out of scope
+- APIM policy implementation in `cpp-azure-api-management` (coordination dependency only).
+- Per-client rate limits / quotas / analytics (AMP standards, later).
+- Physical migration of legacy blobs and retirement of the dual-path resolver.
+- Per-client index/silo migration runbook (logical isolation now; namespace kept so a client can later be routed to its own index/silo via config).
+- The `query_type` PII telemetry fix (adjacent but independent).
+
+## Assumptions
+- APIM (per AMP standards) identifies the consumer upstream and passes a trusted `clientId` to the function app in a recognised internal header; backends trust it because they only accept APIM traffic (function key + network restriction) (D4).
+- `clientId` is a **UUID** for now (D7), pending confirmation (OQ-1).
+- The AI Search chunk `id` is a random UUID (`DocumentChunkingService`), so there is no cross-client key-collision risk in the index.
+- Queues can be fully drained at cut-over, so no dual-write/intermediate-state handling is required (D3).
+- The stale Confluence claims are disregarded: the OData single-quote escaping already exists; the `DocumentStatusCheckFunction` / `GET /document-status` endpoint does not exist (only `DocumentStatusByReferenceFunction`).
+
+## Dependencies
+- **`cpp-azure-api-management`** — APIM policy work to identify the consumer and inject the internal header. This repo defines the internal header contract and enforces behind the D4 abstraction; delivery of enforcement in production depends on that policy landing.
+- **`api-cp-ai-rag`** (spec repo) — must confirm the internal header is NOT added to the consumer spec (D5). Impact assessment needed only if any consumer-facing behaviour changes (none currently planned).
+- **Migration/backfill tooling** must precede the per-environment flag flip.
+
+## Open questions
+1. **OQ-1 — `clientId` final format.** UUID is assumed (D7); confirm before boundary validation is finalised, as the value lands in OData literals, partition keys, blob paths and metric dimensions. — Owner: Mahesh — Due: before design sign-off.
+2. **OQ-2 — `metadataFilter` allow-list.** Is rejecting non-allow-listed `metadataFilter` keys in scope for this iteration (FR-17)? — Owner: TBD — Due: design stage.
+3. **OQ-3 — eval-harness approach (D6).** Simplest approach to keep `ai-document-system-prompt-harness-eval` working against a client-scoped index (inject an incumbent `clientId`? bypass the filter? dedicated eval client?). — Owner: TBD — Due: design stage.
+4. **OQ-4 — incumbent client ID value.** What concrete `clientId` value is assigned to the existing production corpus during migration? — Owner: Mahesh/platform — Due: before backfill run.

--- a/docs/pipeline/DD-42722-multi-tenant-data-isolation/02-design.md
+++ b/docs/pipeline/DD-42722-multi-tenant-data-isolation/02-design.md
@@ -1,0 +1,483 @@
+# Design: Multi-Client Data Isolation (CP AI RAG Service)
+
+> Stage 2 artefact (architecture-designer). Naming is `clientId` throughout (D1). This document is grounded in the current code; every element cites a real class/method. It feeds story-writing and test scaffolding. Requirements: `01-requirements.md` (approved); input brief: `00-input-brief.md`.
+
+## Summary
+
+Introduce per-client logical isolation across the data plane (single AI Search index, single storage account, single set of tables — NFR-1) by threading one `clientId` attribute through every path: a top-level Search field + leading OData filter clause, the Table partition key, a blob path prefix, and a non-optional queue-payload field. Client identity is extracted at the HTTP edge behind **one shared abstraction** (`ClientIdentityResolver`/`ClientContext` in `ai-document-shared-artefacts`, D4), enforced behind `CLIENT_FILTERING_ENABLED` (off = today's behaviour, NFR-2). The existing production corpus is stamped with an incumbent `clientId` before enforcement using the **existing `ai-document-migration-tool`** (index→index copier + table→table copier), extended with a `clientIdOverride` on the index side analogous to the table tool's existing `partitionKeyOverride`. Cut-over is drained-queue, no dual-write (D3).
+
+This is not a new function or endpoint — it is a **cross-cutting extension of five existing functions, the shared artefacts module, and the migration tool**. No consumer OpenAPI contract change (NFR-7/D5).
+
+---
+
+## Verified code baseline (what the design must fit)
+
+| Concern | Real code today | Change vector |
+|---|---|---|
+| HTTP entry points | `DocumentUploadFunction` (`InitiateDocumentUpload`), `DocumentStatusByReferenceFunction`, `SyncAnswerGenerationFunction` (`AnswerRetrieval`), `InitiateAnswerGenerationFunction`, `GetAnswerGenerationResultFunction` — all `authLevel = FUNCTION`, no caller identity | Adopt `ClientIdentityResolver` uniformly |
+| Search filter | `AzureAISearchService.generateFilterExpression(List<KeyValuePair>)` builds `customMetadata/any(...)` + `IS_ACTIVE_FILTER`; `escapeODataStringLiteral` already exists (`StringUtil`) | Prepend leading `clientId eq '…'`; add `clientId` param |
+| Index schema | `vector-db-index-schema-v2.json`; no client field; chunk `id` = random UUID (`DocumentChunkingService.createChunkedEntry`) | Add filterable, non-searchable `clientId` field |
+| Chunk model | `ChunkedEntry` record; written by `DocumentStorageService.uploadChunks`, read by `AzureAISearchService.getColumnsToRetrieve` | Add `clientId` field + `IndexConstants.CLIENT_ID` |
+| Table keying | `DocumentIngestionOutcomeTableService` / `AnswerGenerationTableService` build `new TableEntity(key, key)` everywhere (`insert`, `claimLease`, `createClaimedRow`, `readForClaim` via `getFirstDocumentMatching(key,key)`, `recordOutcomeFenced`, `upsertTerminalFenced`, `recordGroundednessScore`) | PK=clientId, RK=key; client-aware `IdempotencyStatusStore` |
+| Idempotency | `IdempotencyGuard.runOnce(String key, work)`; `ClaimToken(key, etag)`; lease cols `TC_LEASE_OWNER`/`TC_LEASE_EXPIRES_AT` | `runOnce(clientId, key, work)`; `ClaimToken(clientId, key, etag)` |
+| Blob naming | `DocumentBlobNameResolver` regex `^([^_]+)_([0-9]{8})\.[^.]+$`; answer blobs via `ChunkUtil.getAnswerWithChunksFilename/getInputChunksFilename`; `BlobClientService.getSasUrl` (user-delegation SAS, managed identity) | `c={clientId}/` prefix + dual-path parse |
+| Queues | `QueueIngestionMetadata` (`@JsonIgnoreProperties(ignoreUnknown=true)`), `AnswerGenerationQueuePayload`, `ScoringQueuePayload` (filename-only), `ScoringPayload` | Add `clientId` to first two + `ScoringPayload` |
+| Scoring/telemetry | `AnswerScoringFunction` reads `ScoringPayload` blob, `PublishScoreService.publishGroundednessScore(score, userQuery)` → `AzureMonitorService.publishHistogramScore(...,"query_type", userQuery)` (single dimension) | `client_id` dimension; write score back to `(clientId, transactionId)` |
+| Dedup / supersede | `DocumentUploadService.isDocumentAlreadyProcessed(documentId)`; `DocumentStorageService.getSearchResults` filter on `customMetadata` documentId | Scope both to `(clientId, documentId)` |
+| Migration | `IndexCopier` copies `ChunkedEntry` verbatim; `TableCopier` already supports `partitionKeyOverride`; `IndexMigrationTool`/`TableMigrationTool` arg parsing | Add `clientIdOverride` to index tool |
+
+**Environment signal on migration state:** the `ai-service-orchestration-test/.env.sample` and `ai-document-system-prompt-harness-eval/.env.sample` both set `AZURE_SEARCH_SERVICE_INDEX_NAME=ai-rag-service-index` (the raw v1 index name, not an alias), and the two function `local.settings.sample.json` files use placeholders. **Assumption (state explicitly):** the v2 rebuild + alias cutover has **not yet been executed** in the deployed environments — the v2 schema and migration tool exist but config still points at the plain index. This drives decision **DD-4** below (fold the `clientId` field into the pending single v2 rebuild rather than adding a v3). If any environment has already cut over to v2, the fallback (in-place field add via the management API) applies — see §B.
+
+---
+
+## Pattern & Rationale
+
+This spans several buckets simultaneously — it is not one new trigger but a **cross-cutting capability threaded through existing modules**:
+
+- **Reusable identity abstraction across functions → add to `ai-document-shared-artefacts`**. This is the FR-1 single point of change.
+- **HTTP surface:** none. The client-identity header is an **internal APIM↔function contract**, deliberately kept out of the consumer spec (D5/NFR-7). So this is explicitly **not** a `POST /answer-user-query` shape change.
+- **Existing-function extension** for the five HTTP functions, two queue workers, and the scorer.
+- **Migration** stays in the existing not-deployed `ai-document-migration-tool`.
+
+**Sync vs async:** unchanged. Both `SyncAnswerGenerationFunction` (`AnswerRetrieval`) and the async trio (`InitiateAnswerGeneration` → `AnswerGeneration` worker → `GetAnswerGeneration`) already exist; we thread `clientId` through both without altering the sync/async split.
+
+**Rejected shape — new "isolation gateway" function or per-request lookup service:** rejected. Identity is a header set by APIM; a dedicated function would add a hop, a failure mode, and latency for what is a boundary parse + validate. The shared resolver called in-process is simpler and matches D4's "single point of change."
+
+**Rejected shape — index-per-client / storage silo:** rejected per NFR-1 (zero new infra). Logical isolation with `clientId` as a namespace keeps the door open (Confluence retained design point) to route a specific client to its own index later via config only.
+
+---
+
+## Contract Impact
+
+**Internal only — no consumer contract change.** `api-cp-ai-rag` (`ai-rag-service.openapi.yml`) is **unchanged** (NFR-7, D5). The client-identity header is an APIM↔function-app internal contract and must not appear in the spec. Confirm via the `api-contract-check` skill that no `operationId` request/response schema changes (`initiate-document-upload`, `document-status-by-reference`, `answer-user-query`, `answer-user-query-async`, `answer-user-query-status`).
+
+- The new **401** on missing/invalid identity (FR-2) is an enforcement behaviour behind a flag; it is not a documented success/error schema change to a request body. The existing `requestErrored` 400/500 shapes are untouched. If the spec team wants 401 documented as a possible response for completeness, that is a **spec-repo-first** follow-up, but it is not required to ship (the header is invisible to the documented consumer, who always sends it via APIM).
+- The `clientId` value **never appears in any request/response body** — it rides the header inbound and internal storage/queues thereafter. `documentUploadRequest.metadataFilter[]` and `answerUserQueryRequest` are unchanged; a caller cannot set `clientId` through them (AC-3).
+
+---
+
+## A. Client-identity abstraction (`ai-document-shared-artefacts`)
+
+New package `uk.gov.moj.cp.ai.client.identity` (sibling to `uk.gov.moj.cp.ai.idempotency`).
+
+```java
+// The single point of change when AMP finalises the mechanism (D4/FR-1).
+public interface ClientIdentityResolver {
+    /**
+     * @return ClientContext carrying the validated clientId (enforcement on) or an
+     *         empty, unenforced context (flag off).
+     * @throws ClientIdentityException  enforcement on AND identity missing/blank/malformed → maps to 401
+     */
+    ClientContext resolve(HttpRequestMessage<?> request);
+}
+```
+
+```java
+public final class ClientContext {
+    private final String clientId;   // null when unenforced & absent
+    private final boolean enforced;
+
+    public static ClientContext unenforced()              { ... } // flag off
+    public static ClientContext of(String clientId)       { ... } // flag on, resolved
+    public Optional<String> clientId()                    { return Optional.ofNullable(clientId); }
+    public boolean enforced()                             { return enforced; }
+}
+```
+
+```java
+public final class HeaderClientIdentityResolver implements ClientIdentityResolver {
+    // Header name is configurable so AMP can switch to JWT/cookie extraction without a code change (D4).
+    private final String headerName;   // CLIENT_IDENTITY_HEADER, default "X-Client-Id"
+    private final boolean enforced;     // CLIENT_FILTERING_ENABLED (FR-3)
+
+    @Override public ClientContext resolve(HttpRequestMessage<?> request) {
+        final String raw = request.getHeaders().get(headerName.toLowerCase()); // Functions lower-cases header keys
+        if (!enforced) {
+            return ClientContext.unenforced();                 // AC-4: flag off → identity optional
+        }
+        if (isNullOrEmpty(raw) || !UuidUtil.isValid(raw)) {    // NFR-4: UUID validated at the boundary (D7)
+            throw new ClientIdentityException("Missing or invalid client identity");
+        }
+        return ClientContext.of(raw);                          // AC-1
+    }
+}
+```
+
+- **Flag semantics (FR-3):** off → `Optional.empty()` tolerated everywhere (no filter clause, legacy keying/tables); on → resolve-or-401.
+- **UUID validation (NFR-4/D7):** reuse `UuidUtil.isValid` (already used by `DocumentStatusByReferenceFunction` and `GetAnswerGenerationResultFunction`). Because `clientId` lands in an OData literal, a Table partition key, a blob path segment and a metric dimension, validating the UUID shape at ingress makes all four downstream uses safe by construction. (`escapeODataStringLiteral` still applies belt-and-braces in the filter — DD-3.)
+- **Spoof resistance (AC-3):** identity is read only from the header; request body / `metadataFilter` are never consulted.
+- **Adoption in the 5 HTTP functions** — one uniform pattern at the top of each `run(...)`, mapping `ClientIdentityException` → **401** via a shared helper (e.g. `HttpResponses.unauthorized(request)`), reusing each function's existing `generateResponse`:
+
+```java
+final ClientContext ctx;
+try { ctx = clientIdentityResolver.resolve(request); }
+catch (ClientIdentityException e) { return unauthorized(request); }   // FR-2 / AC-2
+```
+
+  Then `ctx.clientId()` is threaded into the service calls below. `InitiateDocumentUpload` and `InitiateAnswerGeneration` copy it onto the queue payload; the two GET functions use it as the Table partition key (→ 404 on cross-client, FR-14); `AnswerRetrieval` threads it into `search(...)` and the `ScoringPayload`.
+
+- **Queue workers have no header.** They recover `clientId` from the queue payload (FR-7/FR-11) and pass it through a small validation guard `ClientId.requireValid(String)` (same `UuidUtil` check) before use. The single *HTTP* abstraction is FR-1; workers trust the payload value that was validated at ingress and re-validate defensively.
+
+---
+
+## B. AI Search — where `clientId` lands
+
+**Decision (DD-4): add a top-level `clientId` field to `vector-db-index-schema-v2.json` and fold it into the single pending v2 rebuild** (`filterable: true, searchable: false, retrievable: true, stored: true, sortable: false, facetable: false`), sitting beside `documentId`. Field-level detail mirrors `documentId`'s v2 row in `SCHEMA_CHANGES.md`.
+
+Rationale, weighing the three options against the migration reality:
+
+- **(i) add to `vector-db-index-schema-v2.json` before the v2 run — CHOSEN.** The environment signal (config still points at `ai-rag-service-index`) indicates the v2 rebuild has not yet run. Adding `clientId` to that schema means the *single* index rebuild does triple duty: v2 attribute correction + `clientId` field creation + incumbent stamping (via the copier `clientIdOverride`, §F). One full sharded pass, no second rebuild. This is exactly what amended FR-4 directs.
+- **(ii) a v3 schema — REJECTED.** Only warranted if v2 has already been cut over. It forces a *second* ~340k-vector rebuild for no attribute benefit. If a given environment turns out to already be on v2, use the fallback below rather than a v3.
+- **(iii) in-place nullable-field add via the management API — REJECTED as the primary path, RETAINED as the fallback.** Adding a *new* field is one of the few schema mutations Azure AI Search permits in place (it is existing-field *attribute* changes that are immutable — the whole premise of `SCHEMA_CHANGES.md`). So for any environment already on v2, add `clientId` in place, then run a targeted stamping pass to backfill. But where v2 hasn't run, in-place add still leaves the full backfill to do and needs its own vehicle — the copier is the proven one — so folding into the rebuild is strictly simpler.
+
+**Assumption to confirm at cut-over:** per environment, check whether `AZURE_SEARCH_SERVICE_INDEX_NAME` already resolves to a v2 alias. If not (expected) → path (i). If yes → path (iii) fallback.
+
+**Code changes:**
+- `IndexConstants`: add `public static final String CLIENT_ID = "clientId";`
+- `ChunkedEntry`: add `@JsonProperty(CLIENT_ID) String clientId` + builder `.clientId(...)`. Additive to the record; JSON stays backward-compatible for legacy blobs/messages (null when absent).
+- `AzureAISearchService.generateFilterExpression(String clientId, List<KeyValuePair> metadataFilters)` — prepend, when `clientId` present (enforcement on), a **non-optional leading clause** ANDed with the rest (FR-5, AC-5):
+
+```java
+if (!isNullOrEmpty(clientId)) {
+    filterBuilder.append(format("%s eq '%s'", IndexConstants.CLIENT_ID, escapeODataStringLiteral(clientId)));
+    // then " and " before the customMetadata clauses / IS_ACTIVE_FILTER
+}
+```
+  `search(...)` gains a `clientId` parameter threaded from `SyncAnswerGenerationFunction` and `AnswerGenerationFunction`. When `clientId` is empty (flag off) the expression is byte-for-byte today's output (AC-4). Escaping via existing `escapeODataStringLiteral` (DD-3).
+- `getColumnsToRetrieve()`: add `IndexConstants.CLIENT_ID` so the field round-trips into `ChunkedEntry` (needed for the scoring payload and telemetry dimension).
+- Ingestion write: `DocumentStorageService.uploadChunks` adds `searchDocument.put(CLIENT_ID, chunkedEntry.clientId())`. `DocumentChunkingService.createChunkedEntry` sets `.clientId(queueMetadata.clientId())` (threaded from `QueueIngestionMetadata`, §E). Chunk `id` stays a random UUID → no cross-client key collision (assumption confirmed).
+- Supersede/deletion scoping (FR-8): `DocumentStorageService.getSearchResults` filter must be scoped — prepend `clientId eq '<clientId>' and (…)` so client A cannot mark client B's chunks inactive. Thread `clientId` from the orchestrator (recovered from `QueueIngestionMetadata`).
+
+**Count-variable invariant** (`SEARCH_NEAREST_NEIGHBOURS_COUNT ≥ SEARCH_TOP_RESULTS_COUNT > SEARCH_MMR_FINAL_COUNT`) is unaffected — the clientId clause only narrows the candidate set, exactly as a metadataFilter does today. The MMR/dedup pipeline order is untouched.
+
+---
+
+## C. Table Storage — re-keying & client-aware idempotency
+
+**Keying (FR-6):** `DocumentIngestionOutcome` → PK=`clientId`, RK=`documentId`; `GeneratedAnswer` → PK=`clientId`, RK=`transactionId`; `clientId` also stored as a non-key column (`TC_CLIENT_ID`) for readability/telemetry. When enforcement is **off**, the effective partition key falls back to the row key (today's PK==RK==key) so legacy rows resolve unchanged (NFR-2).
+
+**New tables vs in-place — DD-5: new tables via the existing `TableCopier`.** A Table `PartitionKey` is immutable (the copier README states exactly this), so re-keying is a copy-into-new-table. The existing `TableCopier` with `partitionKeyOverride=<incumbent clientId>` already does this, non-destructively and idempotently. The app repoints `STORAGE_ACCOUNT_TABLE_DOCUMENT_INGESTION_OUTCOME` / `STORAGE_ACCOUNT_TABLE_ANSWER_GENERATION` to the new table names at cut-over. **No new infra** — same account, new tables (NFR-1 allows tables within the retained account; "single set of tables retained" means one logical set post-migration, the old ones are decommissioned after the reversibility window).
+
+**Client-aware `IdempotencyStatusStore` (FR-7)** — the full interface change (keyed on `(clientId, key)`; a null/blank clientId means legacy PK==RK==key):
+
+```java
+public interface IdempotencyStatusStore {
+    LeaseSnapshot readForClaim(String clientId, String key) throws EntityRetrievalException;
+    boolean isTerminal(String status);
+    String  claimLease(String clientId, String key, String expectedEtag, String owner, OffsetDateTime expiresAt);
+    String  createClaimedRow(String clientId, String key, String owner, OffsetDateTime expiresAt) throws DuplicateRecordException;
+    void    releaseLease(String clientId, String key, String etag);
+}
+```
+
+Both implementations compute `partitionKey = isNullOrEmpty(clientId) ? key : clientId` and replace every `new TableEntity(key, key)` / `getFirstDocumentMatching(key, key)` with `new TableEntity(partitionKey, key)` / `getFirstDocumentMatching(partitionKey, key)`. The fenced terminal writers gain `clientId`:
+- `DocumentIngestionOutcomeTableService`: `insert(clientId, …)`, `upsertDocument(clientId, …)`, `recordOutcomeFenced(clientId, documentId, …)`, `getDocumentById(clientId, documentId)`.
+- `AnswerGenerationTableService`: `saveAnswerGenerationRequest(clientId, …)`, `upsertTerminalFenced(clientId, …)`, `getGeneratedAnswer(clientId, transactionId)`, `recordGroundednessScore(clientId, transactionId, score)`.
+
+**`IdempotencyGuard`** (FR-7, NFR-6):
+```java
+public GuardOutcome runOnce(String clientId, String key, IdempotentWork work) throws Exception
+```
+`claim(...)` threads `clientId` into all store calls. **`ClaimToken` gains `clientId`** (`record ClaimToken(String clientId, String key, String etag)`) so the fenced terminal write in the workers (`upsertTerminalFenced`, `recordOutcomeFenced`) targets the correct partition. All lease semantics — ETag fencing, `LEASE_RELEASED` on release, terminal-skip, live-lease rethrow-vs-WARN, the lease-TTL invariant `IDEMPOTENCY_LEASE_TTL_SECONDS < visibilityTimeout × (maxDequeueCount − 1)` — are preserved verbatim; only the key is now two-part (NFR-6, AC-8).
+
+**Worker call-site changes** (recover `clientId` from the payload *before* claiming — FR-7):
+- `DocumentIngestionFunction`: `idempotencyGuard.runOnce(md.clientId(), documentId, token -> processUnderClaim(...))`; `processQueueMessageFailedIfSafe` and `DocumentIngestionOrchestrator` (`recordOutcome`, `processQueueMessageFailed`) all take `clientId`.
+- `AnswerGenerationFunction`: `runOnce(payload.clientId(), transactionId.toString(), …)`; `recordAnswerGenerationFailed`, `recordAnswerGenerationFailedIfSafe`, `upsertTerminalFenced` all take `clientId` (available from `payload.clientId()` / `token.clientId()`).
+
+**`DocumentUploadFunction` dedup (FR-8, AC-7):** `DocumentUploadService.isDocumentAlreadyProcessed(clientId, documentId)` → `getDocumentById(clientId, documentId)`. Two clients with the same `documentId` land under different partition keys and coexist; dedup, overwrite (`supersededDocuments`) and chunk-deletion are all client-scoped.
+
+**404 semantics (FR-14, AC-14, NFR-3):** `DocumentStatusByReferenceFunction` and `GetAnswerGenerationResultFunction` look up `getDocumentById(ctx.clientId(), documentReference)` / `getGeneratedAnswer(ctx.clientId(), transactionId)`. A row owned by another client lives under a different partition key, so the lookup returns not-found → existing **404** path. No 403, no existence signal — the isolation is a natural consequence of partition scoping, not a special check.
+
+**Rows created while the flag is off:** they live in the *old* tables keyed PK==RK==key. Because keying, table names, alias and flag all flip **together** at cut-over and **queues are drained first (D3)**, there is never a moment where a write lands in the wrong-keyed table mid-flight. The `TableCopier` is re-run as the final pre-flip step (idempotent) to catch any rows written after the initial copy (see §F runbook).
+
+---
+
+## D. Blob strategy
+
+**Prefix (FR-9):** new document blobs at `c={clientId}/{documentId}_{yyyyMMdd}.{ext}`; answer-payload blobs at `c={clientId}/llm-answer-with-chunks-{transactionId}.json` and `c={clientId}/llm-input-chunks-{transactionId}.json`. The `c=` segment is a virtual directory — `BlobClientService.getSasUrl` and `getBlobClient` handle `/`-containing names without change.
+
+**`DocumentBlobNameResolver` dual-path (FR-10, NFR-5):**
+```java
+public String getBlobName(String clientId, String documentId, String ext) {
+    final String flat = format("%s_%s.%s", documentId, today(), ext);
+    return isNullOrEmpty(clientId) ? flat : format("c=%s/%s", clientId, flat);   // flag off → legacy flat
+}
+```
+`getDocumentId(String blobName)` matches both shapes; add a second pattern `^c=([^/]+)/([^_]+)_([0-9]{8})\.[^.]+$` and expose `getClientId(blobName)` returning the prefix's clientId or `null` for legacy flat blobs. The existing flat `BLOB_PATTERN` is retained (AC-10, NFR-5).
+
+**Blob trigger (`DocumentBlobTriggerFunction`):** parse `clientId` from the prefix when present, else treat as legacy (null → incumbent-owned). Look up the Table row by `(clientId, documentId)` and thread `clientId` onto the `QueueIngestionMetadata`. The **Table row is authoritative** for ownership — the path is a convenience, not the source of truth.
+
+**`DocumentUploadFunction`:** builds the blob name via `documentBlobNameResolver.getBlobName(ctx.clientId().orElse(null), documentId, ext)` and SAS as today.
+
+**Answer/scoring blobs:** `ChunkUtil.getAnswerWithChunksFilename(clientId, transactionId)` / `getInputChunksFilename(clientId, transactionId)` prepend the prefix. `GetAnswerGenerationResultFunction` reads the input-chunks blob using `ctx.clientId()`. The **scoring read path needs no change** — `ScoringQueuePayload.filename` already carries the *full* path the producer wrote, so the scorer's `blobService.readBlob(queuePayload.filename(), …)` resolves the prefixed path transparently.
+
+**Legacy blobs stay in place** (out of scope: physical migration / resolver retirement). Flag-off retrieval of a flat-named blob is unchanged (NFR-5).
+
+---
+
+## E. Queue & scoring threading
+
+- `QueueIngestionMetadata` gains `String clientId` (kept last; `@JsonIgnoreProperties(ignoreUnknown=true)` already makes deserialization tolerant, so drained-then-new messages are safe — though D3 means none are in flight). `DocumentBlobTriggerFunction.createQueueMessage` sets it.
+- `AnswerGenerationQueuePayload` gains `String clientId`. `InitiateAnswerGenerationFunction` sets `ctx.clientId()`. It survives redelivery because it is a payload field, so the async / citation-guard retry path (maxDequeueCount 3, lease released before rethrow) re-reads it on every attempt (FR-11, AC-11).
+- **Scoring (FR-12, AC-12):** `ScoringQueuePayload` stays **filename-only** (unchanged). `clientId` rides the `ScoringPayload` blob — add `String clientId` to `ScoringPayload`. Producers (`AnswerGenerationFunction.saveLlmResponseToTheBlobContainer`, `SyncAnswerGenerationFunction`) set it. `AnswerScoringFunction` reads `scoringPayload.clientId()` and writes the score back via `answerGenerationTableService.recordGroundednessScore(scoringPayload.clientId(), scoringPayload.transactionId(), score)`. (Sync path's `ScoringPayload` has `transactionId=null` today → no table write; unchanged, still valid.)
+- **Telemetry (FR-13, AC-13):** `PublishScoreService.publishGroundednessScore(BigDecimal score, String userQuery, String clientId)`; `AzureMonitorService.publishHistogramScore(...)` extended to accept multiple attributes (use `Attributes.builder().put("query_type", userQuery).put("client_id", clientId).build()`), adding a `client_id` dimension for per-client groundedness segmentation. Independent of the separate `query_type` PII concern (out of scope).
+
+---
+
+## Diagrams
+
+### 1. Request flow (sync + async) with clientId threading
+
+```mermaid
+flowchart TD
+    subgraph Edge
+      APIM["APIM policy\n(validates caller,\ninjects X-Client-Id)"]
+    end
+    APIM -->|"X-Client-Id header"| R{{"ClientIdentityResolver\n(flag on: resolve-or-401)"}}
+
+    R -->|sync| SYNC["AnswerRetrieval\n(SyncAnswerGenerationFunction)"]
+    R -->|async initiate| INIT["InitiateAnswerGeneration"]
+    R -->|poll| GET["GetAnswerGeneration"]
+
+    SYNC -->|"search(clientId, q, filters)"| SRCH["AzureAISearchService\nclientId eq '…' AND …"]
+    SRCH --> IDX[("AI Search index\n+ clientId field")]
+    SYNC -->|"ScoringPayload{clientId} blob"| Q3[["answer-scoring queue"]]
+
+    INIT -->|"payload{clientId}"| Q2[["answer-generation queue"]]
+    INIT -->|"PK=clientId row"| TBL[("GeneratedAnswer table\nPK=clientId, RK=txnId")]
+    Q2 --> WORK["AnswerGeneration worker\nrunOnce(clientId, txnId)"]
+    WORK --> SRCH
+    WORK -->|"c={clientId}/… blobs"| BLOB[("Blob: answer/input chunks")]
+    WORK -->|"fenced write PK=clientId"| TBL
+    WORK -->|"ScoringPayload{clientId}"| Q3
+    GET -->|"getGeneratedAnswer(clientId, txnId)\n→ 404 if cross-client"| TBL
+
+    Q3 --> SCORE["AnswerScoring worker"]
+    SCORE -->|"recordGroundednessScore(clientId, txnId)"| TBL
+    SCORE -->|"client_id dimension"| MON[["Azure Monitor"]]
+```
+
+### 2. Ingestion flow
+
+```mermaid
+flowchart TD
+    U["InitiateDocumentUpload\n(ClientContext)"] -->|"dedup (clientId, docId)"| T[("DocumentIngestionOutcome\nPK=clientId, RK=docId")]
+    U -->|"SAS for c={clientId}/{docId}_{date}.pdf"| SAS["BlobClientService.getSasUrl"]
+    Caller["client PUTs bytes"] --> B[("upload container\nc={clientId}/…")]
+    B --> BT["DocumentUploadCheck\n(blob trigger)"]
+    BT -->|"parse clientId from prefix\n(else legacy)"| T
+    BT -->|"QueueIngestionMetadata{clientId}"| Q1[["document-ingestion queue"]]
+    Q1 --> ING["DocumentIngestion worker\nrunOnce(clientId, docId)"]
+    ING --> DI["Document Intelligence"]
+    ING -->|"chunk.clientId = md.clientId"| CH["DocumentChunkingService"]
+    CH --> EMB["embeddings"]
+    EMB -->|"uploadChunks (clientId per chunk)"| IDX[("AI Search index")]
+    ING -->|"supersede filter scoped by clientId"| IDX
+    ING -->|"fenced INGESTION_SUCCESS PK=clientId"| T
+```
+
+### 3. Migration / cut-over sequence (per environment)
+
+```mermaid
+sequenceDiagram
+    participant Op as Release operator
+    participant App as Function app
+    participant Q as Queues
+    participant Idx as AI Search
+    participant Tbl as Tables
+    Op->>App: Deploy code (CLIENT_FILTERING_ENABLED=false, tables=old, index=current)
+    Op->>App: Quiesce write traffic (pause uploads / answer generation)
+    Op->>Q: Drain ingestion + answer-generation + scoring queues (D3)
+    Note over Q: no in-flight messages, no live idempotency leases
+    Op->>Idx: migration-tool index … clientIdOverride=<incumbent> (build v2, stamp clientId)
+    Op->>Tbl: migration-tool table <src> <new> <incumbent> (both tables)
+    Op->>Tbl: (final idempotent re-run of table copy just before flip)
+    Op->>Idx: az rest — repoint alias to v2
+    Op->>App: set AZURE_SEARCH_SERVICE_INDEX_NAME=alias
+    Op->>App: repoint STORAGE_ACCOUNT_TABLE_* to new tables
+    Op->>App: CLIENT_FILTERING_ENABLED=true (enforcement on)
+    Op->>App: Resume traffic
+    Note over Op,App: Rollback = flip flag off + repoint tables to old (+ alias to v1); no data rewrite
+```
+
+---
+
+## F. Migration & cut-over
+
+**Extensions to `ai-document-migration-tool`:**
+- **Index copier — add `clientIdOverride`** (the index-side analogue of `TableCopier`'s existing `partitionKeyOverride`). `IndexMigrationTool` gains a positional/optional `clientIdOverride` arg (blank/`-` = copy verbatim, as the table tool does for maxRecords). `IndexCopier.uploadPage` maps each `ChunkedEntry` to a copy with `.clientId(override)` set before handing to the `DocumentUploader`. Because the copier reads via `result.getDocument(ChunkedEntry.class)` and uploads `ChunkedEntry`, the only prerequisites are (1) `clientId` on `ChunkedEntry` and (2) the `clientId` field on `vector-db-index-schema-v2.json` (§B). Uploads stay idempotent upserts keyed by `id`; re-runs are safe.
+- **Table copier — no change needed.** It already rewrites `PartitionKey` to a fixed value and copies data columns verbatim. Run it twice, once per table, with `partitionKeyOverride=<incumbent clientId>`. Because queues are drained (D3) there are **no live leases** at migration time, so the FR-15 "skip rows under live leases" concern does not arise — all rows are terminal or non-terminal-but-quiescent and copy safely (stale `LeaseExpiresAt`/`LeaseOwner` columns copy harmlessly; an expired/released lease in the new table is reclaimable). *Optional belt-and-braces:* a `--terminal-only` filter, but not required given D3.
+
+**Per-environment runbook** (see diagram 3): deploy (flag off) → quiesce writes → **drain queues** → index copy+stamp (v2) → table copy+rekey (×2) → final idempotent table re-copy → repoint alias → repoint table env vars → **flip flag on** → resume → onboard further clients via APIM config only.
+
+**Alias ↔ flag interaction:** the alias repoint and the `CLIENT_FILTERING_ENABLED` flip are **independent levers**. v2 works with the flag off (the `clientId` field is simply unused, and `generateFilterExpression` omits the clause). So the alias can move to v2 ahead of enforcement. The **true reversible levers are the flag + the table-name env vars**: flip flag off and repoint tables back to the (untouched) old tables and the service is exactly as before — **no data rewrite** (NFR-2). The alias can safely stay on v2 during rollback (superset data; flag-off ignores `clientId`). **OQ-4** (incumbent `clientId` value) is supplied as the migration-tool argument, not an app env var.
+
+---
+
+## G. OQ-2 recommendation — `metadataFilter` allow-list (FR-17)
+
+**Recommend: general allow-list OUT of scope this iteration; add a cheap reserved-key rejection instead.**
+
+Rationale grounded in the code: `clientId` is a **top-level** Search field, whereas `metadataFilter` entries are compiled by `generateFilterExpression` into `customMetadata/any(m: m/key eq '…')` clauses. A caller putting `key=clientId` in `metadataFilter` produces a `customMetadata/any(...)` clause that can **never** match the top-level `clientId` field — so it cannot weaken the mandatory leading `clientId eq '…'` clause. Isolation does **not** depend on the allow-list. A full product-facing allow-list needs its own spec/product discussion and risks breaking legitimate metadata keys. **Minimal hardening to include now:** reject `metadataFilter` keys in a small reserved set (`clientId`, `is_active`) with 400 at the HTTP boundary — defence-in-depth against confusion/log-noise, one guard, no contract change. **Stakeholder decision (2026-07-20): the rejection is always-on — NOT gated by `CLIENT_FILTERING_ENABLED`** (defence-in-depth applies pre-cutover too; these keys are internal and no legitimate caller uses them today). Track the general allow-list as a separate follow-up.
+
+## H. OQ-3 recommendation — eval harness (FR-18)
+
+**Recommend: harness supplies a configured incumbent `clientId` via its `.env` and threads it into the search path it already exercises, with enforcement on.**
+
+`ai-document-system-prompt-harness-eval` runs the embed→search→generate→cite pipeline directly against `AzureAISearchService` (not via HTTP), and its `.env.sample` already sets `AZURE_SEARCH_SERVICE_INDEX_NAME`. Simplest: add `EVAL_CLIENT_ID` (set to the incumbent clientId the corpus is stamped with) and `CLIENT_FILTERING_ENABLED=true` to the harness `.env`, and pass `EVAL_CLIENT_ID` into the `search(clientId, …)` call. This exercises the **real filtered path**, so eval metrics reflect production.
+- *Alternative — run the harness with the flag off (no filter):* rejected — eval would no longer mirror prod behaviour once enforcement is on.
+- *Alternative — dedicated eval client with its own corpus:* rejected as heavier and unnecessary; the incumbent-stamped corpus is exactly what prod queries.
+
+---
+
+## Reliability
+
+- **Idempotency key** becomes `(clientId, key)`; `IdempotencyGuard.runOnce(clientId, key, work)`, `ClaimToken(clientId, key, etag)`. Terminal-skip statuses unchanged (`INGESTION_SUCCESS/INGESTION_FAILED/FILE_SIZE_OVER_LIMIT`, `ANSWER_GENERATED/ANSWER_GENERATION_FAILED`).
+- **Redelivery:** `clientId` is a payload field, so it is present on every one of the maxDequeueCount (3) attempts, including citation-guard retries (AC-11). The lease-release-before-rethrow contract (`RedeliveryException` / `DocumentProcessingException`) is unchanged.
+- **Lease-TTL invariant** `IDEMPOTENCY_LEASE_TTL_SECONDS < visibilityTimeout × (maxDequeueCount − 1)` is unchanged — keying does not affect timing.
+- **Fencing:** the fenced terminal writes (`recordOutcomeFenced`, `upsertTerminalFenced`) now target PK=clientId; the ETag semantics and 412→`EtagMismatchException` handling are identical (NFR-6, AC-8).
+- **Poison/exhaustion:** the WARN-and-leave-non-terminal behaviour on a live lease at exhaustion is preserved (now scoped per client partition).
+
+---
+
+## Cross-cutting
+
+- **Auth (managed identity):** no new credential path. `DefaultAzureCredential` unchanged for Search/Table/Blob. Client identity is an APIM-injected header, trusted because backends only accept APIM traffic (function key + network restriction). No connection strings/SAS/keys added.
+- **New env vars** (document in each module's `Azure/local.settings.sample.json` **and** root `CLAUDE.md`):
+  - `CLIENT_FILTERING_ENABLED` (default `false`) — enforcement flag (FR-3), all five HTTP functions + both workers + retrieval + scoring.
+  - `CLIENT_IDENTITY_HEADER` (default `X-Client-Id`) — internal header name, HTTP functions only (D4 single point of change).
+  - `EVAL_CLIENT_ID` — harness `.env` only (OQ-3).
+  - No new **infra** env vars: the new table names reuse `STORAGE_ACCOUNT_TABLE_*` (repointed at cut-over); the alias reuses `AZURE_SEARCH_SERVICE_INDEX_NAME`; incumbent clientId is a migration-tool argument (OQ-4).
+- **Validation:** UUID at the HTTP boundary (`UuidUtil.isValid`, NFR-4/D7); OData escaping via existing `escapeODataStringLiteral` (DD-3); worker-side `ClientId.requireValid` on payload values; blob-name parse validated by `DocumentBlobNameResolver`.
+- **Logging (`context.getLogger()`/slf4j):** `clientId` (a UUID, non-PII) may be logged for traceability; never log the raw header alongside request bodies. No new PII surface.
+
+---
+
+## Risks & Trade-offs
+
+| # | Risk | Likelihood/Impact | Mitigation |
+|---|---|---|---|
+| 1 | **Broad, mechanical fan-out** of the `(clientId, key)` signature change across `IdempotencyStatusStore`, both table services, `IdempotencyGuard`, `ClaimToken`, both workers, orchestrator — easy to miss a call site and break fencing (NFR-6) | Med / High | Keep the null-clientId→legacy-keying fallback so flag-off tests pass unchanged; exhaustive unit coverage on both stores; AC-8 idempotency regression test under client-aware keys |
+| 2 | **Cut-over ordering error** — flipping the flag before repointing tables/alias, or before the final table re-copy, silently drops rows written during the window | Med / High | The drained-queue rule (D3) plus "quiesce writes → drain → migrate → final idempotent re-copy → repoint → flip" runbook; table copy is idempotent so re-run just before flip |
+| 3 | **Environment already on v2** invalidates the "fold into v2 rebuild" assumption (DD-4) | Low / Med | Per-env check of `AZURE_SEARCH_SERVICE_INDEX_NAME` at cut-over; fallback = in-place field add (management API) + stamping pass (§B option iii) |
+| 4 | **APIM header contract not yet concrete** (AMP owns it) — header name/shape may change | Med / Low | `HeaderClientIdentityResolver` + `CLIENT_IDENTITY_HEADER` isolate all change to one class (D4/FR-1); JWT/cookie extraction is a single-method swap |
+| 5 | **Legacy flat-path blobs** mis-parsed by the dual-path resolver → retrieval regression (NFR-5) | Low / Med | Retain the existing `BLOB_PATTERN` untouched; add the prefixed pattern as a distinct branch; AC-10 test on both shapes |
+| 6 | **Telemetry cardinality** — `client_id` dimension multiplies metric series | Low / Low | clientId is bounded (few onboarded clients); the existing `query_type=userQuery` dimension is a far larger cardinality concern (tracked separately) |
+
+**Reversibility:** high for the runtime toggle (flag + table-name env vars, NFR-2 — no data rewrite). The **one-way-ish door** is the alias repoint (harmless to leave on v2) and, more importantly, the storage-key choice (`clientId` as PK): once clients depend on it, un-isolating means another migration.
+
+---
+
+## Design decisions
+
+- **DD-1 — `clientId` everywhere** (D1). *Alt: `tenantId`* — rejected by stakeholder.
+- **DD-2 — Identity extraction behind one shared `ClientIdentityResolver`/`ClientContext` in `ai-document-shared-artefacts`** (FR-1/D4). *Alt: per-function header parsing* — rejected: no single point of change when AMP finalises. *Alt: dedicated gateway function* — rejected: extra hop/latency for a boundary parse.
+- **DD-3 — Reuse existing `escapeODataStringLiteral` + boundary UUID validation** for the `clientId eq '…'` clause; no new escaping. *Alt: parameterised OData* — not supported by the SDK filter API; the double-quote escape + UUID shape validation is sufficient (NFR-4).
+- **DD-4 — Add `clientId` to `vector-db-index-schema-v2.json` and fold into the single pending v2 rebuild** (FR-4 amended). *Alt: v3 schema* — rejected (second full rebuild). *Alt: in-place add only* — retained as the already-on-v2 fallback.
+- **DD-5 — Re-key tables via new tables + existing `TableCopier` `partitionKeyOverride`, repoint env vars at cut-over.** *Alt: in-place re-key* — impossible (PartitionKey immutable). *Alt: dual-write during migration* — rejected (D3 drained-queue removes the need).
+- **DD-6 — Client-aware `(clientId, key)` idempotency with null-clientId legacy fallback**, preserving all lease/fence semantics (FR-7/NFR-6).
+- **DD-7 — `clientId` on `ScoringPayload` blob, not `ScoringQueuePayload`** (FR-12); scorer writes score to `(clientId, transactionId)`.
+- **DD-8 — Blob `c={clientId}/` prefix with dual-path resolver; Table row authoritative for ownership** (FR-9/FR-10); legacy blobs left in place.
+- **DD-9 — Extend the index copier with `clientIdOverride`** (analogue of the table tool's `partitionKeyOverride`); table copier unchanged (FR-15/FR-16).
+- **DD-10 — 404 (not 403) on cross-client lookup as a natural consequence of partition scoping** (FR-14/NFR-3), no special-case check.
+- **DD-11 — Flag + table-name env vars are the reversible levers; alias repoint is independent** and may remain on v2 during rollback (NFR-2).
+- **DD-12 — metadataFilter allow-list deferred; reserved-key rejection added, always-on (not flag-gated)** (OQ-2, stakeholder decision 2026-07-20) — isolation does not depend on it.
+- **DD-13 — Eval harness runs enforcement-on with an incumbent `EVAL_CLIENT_ID`** (OQ-3).
+
+---
+
+## Module-by-module change inventory
+
+**`ai-document-shared-artefacts`**
+- New: `uk/gov/moj/cp/ai/client/identity/{ClientIdentityResolver, HeaderClientIdentityResolver, ClientContext, ClientIdentityException, ClientId}.java`
+- `index/IndexConstants.java` — add `CLIENT_ID`
+- `model/ChunkedEntry.java` — add `clientId` field + builder
+- `model/QueueIngestionMetadata.java` — add `clientId`
+- `model/ScoringPayload.java` — add `clientId`
+- `idempotency/IdempotencyStatusStore.java`, `IdempotencyGuard.java`, `ClaimToken.java` — `(clientId, key)` API
+- `service/table/DocumentIngestionOutcomeTableService.java`, `AnswerGenerationTableService.java` — clientId keying + method signatures; add `TC_CLIENT_ID` to `entity/StorageTableColumns.java`
+- `SharedSystemVariables.java` — add `CLIENT_FILTERING_ENABLED`, `CLIENT_IDENTITY_HEADER`
+- `src/main/resources/vector-db-index-schema-v2.json` — add `clientId` field
+
+**`ai-document-metadata-check-function`**
+- `DocumentUploadFunction.java` — resolver + 401; `getBlobName(clientId, …)`; dedup `(clientId, documentId)`
+- `DocumentBlobTriggerFunction.java` — parse clientId from prefix; set on `QueueIngestionMetadata`; `(clientId, documentId)` row lookup
+- `utils/DocumentBlobNameResolver.java` — prefixed `getBlobName` + dual-path `getDocumentId` + `getClientId`
+- `service/DocumentUploadService.java` — clientId-scoped methods
+- `Azure/local.settings.sample.json`
+
+**`ai-document-ingestion-function`**
+- `DocumentIngestionFunction.java` — `runOnce(md.clientId(), documentId, …)`
+- `service/DocumentIngestionOrchestrator.java` — thread clientId into `recordOutcome`, superseding, failure paths
+- `service/DocumentChunkingService.java` — set `chunk.clientId`
+- `service/DocumentStorageService.java` — `uploadChunks` writes `clientId`; `getSearchResults` filter scoped by clientId
+- `Azure/local.settings.sample.json`
+
+**`ai-document-answer-retrieval-function`**
+- `SyncAnswerGenerationFunction.java` (`AnswerRetrieval`) — resolver + 401; `search(clientId, …)`; clientId into `ScoringPayload`
+- `InitiateAnswerGenerationFunction.java` — resolver + 401; clientId onto `AnswerGenerationQueuePayload` + pending row
+- `AnswerGenerationFunction.java` (worker) — `runOnce(payload.clientId(), …)`; clientId through fenced writes, `ScoringPayload`, failure paths
+- `GetAnswerGenerationResultFunction.java` — resolver + 401; `(clientId, transactionId)` lookup → 404; clientId in input-chunks blob path
+- `model/AnswerGenerationQueuePayload.java` — add `clientId`
+- `service/AzureAISearchService.java` — `generateFilterExpression(clientId, …)`, `search(clientId, …)`, `getColumnsToRetrieve` + CLIENT_ID
+- `util/ChunkUtil.java` — clientId-prefixed filenames
+- `Azure/local.settings.sample.json`
+
+**`ai-document-status-check-function`**
+- `DocumentStatusByReferenceFunction.java` — resolver + 401; `(clientId, documentReference)` lookup → 404
+- `Azure/local.settings.sample.json`
+
+**`ai-document-answer-scoring-function`**
+- `AnswerScoringFunction.java` — read `scoringPayload.clientId()`; `recordGroundednessScore(clientId, txnId, score)`
+- `service/PublishScoreService.java` — clientId param
+- `service/AzureMonitorService.java` — multi-attribute `publishHistogramScore` with `client_id`
+
+**`ai-document-migration-tool`**
+- `index/IndexMigrationTool.java` — parse `clientIdOverride` arg
+- `index/IndexCopier.java` (and `uploadPage`) — stamp `ChunkedEntry.clientId` when override set
+- README/SCHEMA_CHANGES doc updates
+
+**`ai-document-system-prompt-harness-eval`** — `.env.sample` adds `EVAL_CLIENT_ID`, `CLIENT_FILTERING_ENABLED`; search call passes clientId.
+
+**`ai-service-orchestration-test`** — `x-client-id`/`X-Client-Id` header on all request helpers; second-client fixture; new tests (cross-client 404, filter clause, header 401, spoof override).
+
+**Root `CLAUDE.md`** — env-var section: `CLIENT_FILTERING_ENABLED`, `CLIENT_IDENTITY_HEADER`; module table gains `ai-document-migration-tool`.
+
+---
+
+## Phased implementation outline (feeds story-writer)
+
+**Phase 0 — Shared foundations (merge safely, flag off, no behaviour change)**
+- Add `ClientIdentityResolver`/`HeaderClientIdentityResolver`/`ClientContext`/`ClientIdentityException`/`ClientId` + `CLIENT_FILTERING_ENABLED`/`CLIENT_IDENTITY_HEADER` (default off → `unenforced()`; AC-4).
+- Add `IndexConstants.CLIENT_ID`, `ChunkedEntry.clientId`, `TC_CLIENT_ID`, `clientId` on `QueueIngestionMetadata`/`AnswerGenerationQueuePayload`/`ScoringPayload` (all additive/nullable).
+- Add `clientId` field to `vector-db-index-schema-v2.json`.
+
+**Phase 1 — Client-aware storage (flag-gated behaviour; legacy path preserved)**
+- Client-aware `IdempotencyStatusStore`/`IdempotencyGuard`/`ClaimToken`; null-clientId→legacy keying; AC-8 regression.
+- Client-scoped table service methods; `DocumentUploadService` dedup `(clientId, documentId)`; AC-7.
+- `generateFilterExpression(clientId, …)` + `search(clientId, …)`; AC-5/AC-6.
+- Blob prefix + dual-path resolver; AC-9/AC-10.
+
+**Phase 2 — Wire the five functions + workers + scorer to the resolver (flag on = enforcement)**
+- Resolver+401 in all five HTTP functions (FR-2/AC-1/AC-2/AC-3); 404 in the two GETs (AC-14).
+- clientId threaded onto both queue payloads + `ScoringPayload`; workers `runOnce(clientId, …)`; AC-11/AC-12.
+- Telemetry `client_id` dimension; AC-13.
+- Reserved-key rejection (OQ-2 minimal).
+
+**Phase 3 — Migration tooling & harness**
+- `clientIdOverride` in the index copier; verify table copier run recipe (AC-15/AC-16).
+- Harness `.env` + search-path clientId (OQ-3).
+
+**Phase 4 — Cut-over (per environment, operator-run)**
+- Execute the runbook (§F) per environment; validate; keep old tables/v1 index for the reversibility window.
+
+**Flag-gated vs merge-safe:** Phase 0 and the *code* of Phases 1–3 merge safely with the flag off (behaviour identical to today, NFR-2). Enforcement (401, filter clause, client keying against new tables, prefixed blobs) only activates when `CLIENT_FILTERING_ENABLED=true` **and** the env is repointed at the migrated tables/alias — i.e. at cut-over.
+
+---
+
+## Follow-ups
+
+- **ADR recommended:** "Logical multi-client isolation via a single `clientId` namespace (Search field + Table partition key + blob prefix + queue field) behind `CLIENT_FILTERING_ENABLED`." Capture the one-way doors (partition-key choice; alias-on-v2) and DD-1…DD-13.
+- **Spec-repo follow-up (optional):** if the API team wants 401 documented as a possible response, that is an `api-cp-ai-rag`-first change; not required to ship (header is invisible to the documented consumer).
+- **Open questions to close before cut-over:** OQ-1 (`clientId` final format — UUID assumed, drives NFR-4), OQ-4 (incumbent `clientId` value — migration-tool argument).
+- **Coordination dependency:** `cpp-azure-api-management` must land the policy that injects the header (matching `CLIENT_IDENTITY_HEADER`); production enforcement depends on it.

--- a/docs/pipeline/DD-42722-multi-tenant-data-isolation/03-stories.md
+++ b/docs/pipeline/DD-42722-multi-tenant-data-isolation/03-stories.md
@@ -1,0 +1,431 @@
+# User Stories: Multi-Client Data Isolation (CP AI RAG Service)
+
+> Stage 3 artefact (story-writer). Source: `01-requirements.md` (approved), `02-design.md` (approved), `00-input-brief.md`.
+
+## Jira mapping
+
+Parent ticket: [DD-42722](https://tools.hmcts.net/jira/browse/DD-42722) — "Implement multi tenant data structure and storage". Each story below is a lightweight Jira sub-task (user story + description + pointer back to this file); this document remains the source of truth for acceptance criteria, DoD and dependencies. In Jira text, story IDs are written hyphen-free (`MTDI01`) to avoid Jira auto-linking pseudo issue keys.
+
+| Story | Jira sub-task |
+|---|---|
+| MTDI-01 | [DD-42976](https://tools.hmcts.net/jira/browse/DD-42976) |
+| MTDI-02 | [DD-42977](https://tools.hmcts.net/jira/browse/DD-42977) |
+| MTDI-03 | [DD-42978](https://tools.hmcts.net/jira/browse/DD-42978) |
+| MTDI-04 | [DD-42979](https://tools.hmcts.net/jira/browse/DD-42979) |
+| MTDI-05 | [DD-42980](https://tools.hmcts.net/jira/browse/DD-42980) |
+| MTDI-06 | [DD-42981](https://tools.hmcts.net/jira/browse/DD-42981) |
+| MTDI-07 | [DD-42982](https://tools.hmcts.net/jira/browse/DD-42982) |
+| MTDI-08 | [DD-42983](https://tools.hmcts.net/jira/browse/DD-42983) |
+| MTDI-09 | [DD-42984](https://tools.hmcts.net/jira/browse/DD-42984) |
+
+**Cross-cutting rule for every dev story (S1–S8):** each must be independently mergeable to `main` with `CLIENT_FILTERING_ENABLED` off/unset, producing **byte-for-byte identical behaviour** to today (NFR-2, AC-4). Enforcement only activates at Phase 4 cut-over, once the flag is flipped **and** the environment is repointed at migrated tables/index alias. The one deliberate exception is MTDI-04's reserved-key rejection, which is **always-on** (not flag-gated) per stakeholder decision 2026-07-20 — see MTDI-04's notes.
+
+**ADR gate:** this initiative requires an ADR before implementation begins — *"Logical multi-client isolation via a single `clientId` namespace (Search field + Table partition key + blob prefix + queue field) behind `CLIENT_FILTERING_ENABLED`"*, capturing design decisions DD-1…DD-13 and the identified one-way doors (partition-key choice; alias-on-v2). Store it under `docs/pipeline/adrs/` and get tech-lead sign-off **before MTDI-01 starts** — it is a merge gate for the whole story set.
+
+---
+
+## Summary table
+
+| Story ID | Title | Phase | Size | Dependencies | Can run in parallel with |
+|---|---|---|---|---|---|
+| MTDI-01 | Shared client-identity abstraction + feature-flag env vars | Phase 0 | M | None (ADR must be accepted first) | MTDI-02 |
+| MTDI-02 | Additive client-scoping fields across models, schema and queue payloads | Phase 0 | M | None (ADR must be accepted first) | MTDI-01 |
+| MTDI-03 | Client-aware idempotency store/guard + Table Storage re-keying | Phase 1 | L | MTDI-01, MTDI-02 | MTDI-04, MTDI-05, MTDI-07 |
+| MTDI-04 | Search filter clause, retrieval threading & reserved-metadata-key rejection | Phase 1 | M | MTDI-01, MTDI-02 | MTDI-03, MTDI-05, MTDI-07 |
+| MTDI-05 | Blob path prefixing with dual-path (legacy) resolution | Phase 1 | M | MTDI-02 | MTDI-03, MTDI-04, MTDI-07 |
+| MTDI-06 | Wire the five HTTP functions, two queue workers and scorer to client identity | Phase 2 | L | MTDI-01…05 | — (integration point; sequential) |
+| MTDI-07 | Migration-tool `clientIdOverride` + documentation updates | Phase 3 | S | MTDI-02 | MTDI-03, MTDI-04, MTDI-05, MTDI-06 |
+| MTDI-08 | Eval harness client scoping + integration-test suite additions | Phase 3 | M | MTDI-06 (and MTDI-04 for the filter-injection regression) | MTDI-07 |
+| MTDI-09 | **[OPS — not a code story]** Per-environment cut-over runbook execution | Phase 4 | S (ops) | MTDI-06, MTDI-07, MTDI-08 all merged & deployed | — (sequential, per environment) |
+
+**Estimation legend:** S = fits comfortably in a few days within one sprint; M = most of a sprint for one engineer/pair; L = a full sprint, or split across two engineers working sub-slices in the same story (kept as one story because the change is not independently shippable in smaller pieces without breaking a single interface's contract — e.g. `IdempotencyStatusStore`'s signature).
+
+**Parallelisation:** MTDI-01 and MTDI-02 (Phase 0) have no interdependency and should be started together. Once both land, MTDI-03, MTDI-04, MTDI-05 (Phase 1) and MTDI-07 (Phase 3, different module — `ai-document-migration-tool`) can all proceed in parallel, since they touch disjoint modules/classes. MTDI-06 is the integration point and must wait for MTDI-01–05 to land (it is intentionally the widest-fan-in story). MTDI-08 needs MTDI-06 merged (it exercises the full flag-on path end to end) but can start test-scaffolding work (fixtures, harness `.env` wiring) as soon as MTDI-04 lands. MTDI-09 is strictly sequential and last, run once per environment by the release operator.
+
+---
+
+## MTDI-01: Shared client-identity abstraction + feature-flag env vars
+
+### User story
+As a **platform engineer maintaining the CP AI RAG Service**,
+I want **a single, shared client-identity resolution abstraction in `ai-document-shared-artefacts`, gated behind a `CLIENT_FILTERING_ENABLED` flag**,
+so that **every HTTP function can later adopt one consistent, testable way to extract and validate the caller's `clientId`, with a single point of change when APIM's identity mechanism (AMP, D4) is finalised**.
+
+### Background
+FR-1/FR-2/FR-3 (D4, D5, D7). This is foundational plumbing only — **no HTTP function is wired to it yet** (that's MTDI-06). It must be safe to merge in isolation: it introduces new classes and new, unused-by-default env vars, with zero behavioural change to any existing endpoint.
+
+### Acceptance criteria
+- [ ] AC-001 (delivers AC-1, unit level): Given `CLIENT_FILTERING_ENABLED=true` and a request carrying a valid UUID in the `CLIENT_IDENTITY_HEADER` header, when `HeaderClientIdentityResolver.resolve(request)` is called, then it returns `ClientContext.of(clientId)` with `enforced()==true` and `clientId()` populated.
+- [ ] AC-002 (delivers AC-2, unit level): Given `CLIENT_FILTERING_ENABLED=true` and the header is absent, empty, or not a valid UUID, when `resolve(request)` is called, then it throws `ClientIdentityException` (mapped by callers to 401 — the mapping itself is verified in MTDI-06).
+- [ ] AC-003 (delivers AC-3, unit level): Given a request whose body or `metadataFilter` contains a different clientId-like value, when `resolve(request)` is called, then only the header value is used; body/`metadataFilter` content has no effect on the resolved `ClientContext`.
+- [ ] AC-004 (delivers AC-4, unit level): Given `CLIENT_FILTERING_ENABLED=false` (or unset — default), when `resolve(request)` is called regardless of header presence, then it returns `ClientContext.unenforced()` with `clientId()` empty and `enforced()==false` — no exception is ever thrown in this mode.
+- [ ] AC-005: Given a malformed but non-empty header value (not a valid UUID format per NFR-4/D7), when enforcement is on, then `ClientIdentityException` is thrown (same as AC-002) — validated via `UuidUtil.isValid` reuse, not a new validation routine.
+- [ ] AC-006: Given `CLIENT_IDENTITY_HEADER` is unset, when the resolver is constructed, then it defaults to `X-Client-Id` (case-insensitive lookup, since the Functions host lower-cases header keys).
+- [ ] AC-007: Given the worker-side helper `ClientId.requireValid(String)`, when called with a null/blank/non-UUID value, then it throws the same validation exception type used at the HTTP boundary, so queue workers (wired in MTDI-06) can defensively re-validate a payload-carried `clientId` with one shared routine.
+
+### NFR links
+- NFR-2 (Reversibility): flag defaults to `false`; toggling it back off requires no data rewrite.
+- NFR-4 (Input validation): UUID-shape validation happens once, at this single point, before `clientId` can reach any OData literal, partition key, blob path or metric dimension downstream.
+- NFR-7 (Contract stability): the header and flag are internal-only; nothing here touches `api-cp-ai-rag`.
+
+### Out of scope for this story
+- Wiring `ClientIdentityResolver`/`ClientContext` into any of the five HTTP functions (MTDI-06).
+- Mapping `ClientIdentityException` → HTTP 401 response body/status (MTDI-06, `HttpResponses.unauthorized`).
+- Any change to `AzureAISearchService`, Table services, blob naming, or queue payloads (MTDI-02/03/04/05).
+
+### Definition of done
+- [ ] Code reviewed and approved (≥1 human approval per branch policy; no direct commits to `main`).
+- [ ] New package `uk.gov.moj.cp.ai.client.identity` (`ClientIdentityResolver`, `HeaderClientIdentityResolver`, `ClientContext`, `ClientIdentityException`, `ClientId`) added to `ai-document-shared-artefacts` with unit tests covering all ACs above.
+- [ ] `SharedSystemVariables` gains `CLIENT_FILTERING_ENABLED` (default `false`) and `CLIENT_IDENTITY_HEADER` (default `X-Client-Id`); documented in root `CLAUDE.md`'s environment-variable section.
+- [ ] `mvn test -pl ai-document-shared-artefacts` passes; `mvn verify` shows JaCoCo coverage ≥80% on all new classes.
+- [ ] No integration-test changes required for this story (nothing is wired yet) — confirmed by running the existing `ai-service-orchestration-test` suite unchanged and green.
+- [ ] SonarQube quality gate passes on the Azure Pipelines PR build.
+- [ ] Verified with a manual/unit check that `CLIENT_FILTERING_ENABLED=false` (or absent) never throws, matching current behaviour of every existing caller.
+
+### Notes / open questions
+- ADR gate applies (see initiative header) — must be accepted before this story's PR merges.
+- OQ-1 (`clientId` format — UUID assumed, D7) should be confirmed by the time this story starts; if it changes, only `ClientId`/`UuidUtil` usage here needs revisiting (that's the point of the single-abstraction design, DD-2).
+- `HttpResponses.unauthorized(request)` helper is a natural companion but is deferred to MTDI-06 since no caller needs it yet — flag if reviewers want it stubbed here instead.
+
+---
+
+## MTDI-02: Additive client-scoping fields across models, schema and queue payloads
+
+### User story
+As a **platform engineer preparing the data plane for client isolation**,
+I want **`clientId` added as an additive, nullable field to every model, DTO, table column and the pending v2 Search index schema that will eventually carry it**,
+so that **later stories (idempotency re-keying, search filtering, blob prefixing, worker wiring) have a stable, backward-compatible shape to build against, with zero behavioural change today**.
+
+### Background
+FR-4 (index field), FR-6 (`TC_CLIENT_ID` column), FR-11/FR-12 (queue/scoring payload fields), DD-4 (fold `clientId` into the single pending v2 index rebuild rather than a v3). All changes here are additive fields on existing records/JSON — no reader depends on the field being present yet, and `@JsonIgnoreProperties(ignoreUnknown = true)` on the queue DTOs already makes this safe for any message drained mid-rollout (though D3 means none are in flight at cut-over anyway).
+
+### Acceptance criteria
+- [ ] AC-008: Given `IndexConstants`, when this story lands, then `CLIENT_ID = "clientId"` is defined and used by no production code path yet (verified by a compile-time reference check / grep in review — actual usage lands in MTDI-04).
+- [ ] AC-009: Given `ChunkedEntry`, when a chunk is built without a `clientId` (today's callers), then serialisation/deserialisation is unchanged and `clientId` defaults to `null`; when built with `.clientId("...")`, then the value round-trips through JSON.
+- [ ] AC-010: Given `vector-db-index-schema-v2.json`, when the schema is loaded, then it declares a `clientId` field (`filterable: true, searchable: false, retrievable: true, stored: true, sortable: false, facetable: false`) matching `documentId`'s v2 attribute shape.
+- [ ] AC-011: Given `QueueIngestionMetadata` and `AnswerGenerationQueuePayload`, when a message is deserialised without a `clientId` property (legacy/pre-rollout shape), then deserialisation succeeds with `clientId == null`.
+- [ ] AC-012: Given `ScoringPayload`, when built by the existing producers unchanged in this story, then the payload still serialises correctly with `clientId` simply absent/null (producers are updated to set it in MTDI-06).
+- [ ] AC-013: Given `entity/StorageTableColumns`, when this story lands, then `TC_CLIENT_ID` is defined as a constant, unused by any table read/write path yet (usage lands in MTDI-03).
+
+### NFR links
+- NFR-1 (No new infra): this is a field addition to the existing single index/tables, not a new resource.
+- NFR-5 (Backward compatibility): every change here is additive and nullable; nothing currently reading these models/messages/schema breaks.
+
+### Out of scope for this story
+- Any code that *reads* `clientId` from these fields to change behaviour (filtering, keying, prefixing) — MTDI-03/04/05/06.
+- Running the actual v2 index rebuild/backfill against a live environment (MTDI-07 tool, MTDI-09 runbook).
+- `AzureAISearchService.getColumnsToRetrieve()` change to include `CLIENT_ID` (bundled into MTDI-04, part of the search-service read path).
+
+### Definition of done
+- [ ] Code reviewed and approved.
+- [ ] All listed model/DTO/schema/constant changes made in `ai-document-shared-artefacts` (`IndexConstants`, `ChunkedEntry`, `QueueIngestionMetadata`, `ScoringPayload`, `StorageTableColumns`, `vector-db-index-schema-v2.json`).
+- [ ] Unit tests added for each additive field's serialise/deserialise-without-field backward-compatibility case (AC-009, AC-011, AC-012).
+- [ ] `mvn test -pl ai-document-shared-artefacts` passes; `mvn verify` JaCoCo coverage ≥80% on new/changed lines.
+- [ ] Existing `ai-service-orchestration-test` suite re-run unchanged and green.
+- [ ] SonarQube quality gate passes on the Azure Pipelines PR build.
+- [ ] `SCHEMA_CHANGES.md` updated documenting the `clientId` field addition and its place in the pending v2 rebuild (DD-4), including the fallback path (in-place add via management API) for any environment already cut over to v2.
+
+### Notes / open questions
+- Confirm per-environment whether `AZURE_SEARCH_SERVICE_INDEX_NAME` already resolves to a v2 alias before MTDI-07/09 run (design Risk #3) — this story only prepares the schema.
+- `AnswerGenerationQueuePayload.clientId` added last in field order for consistency with `QueueIngestionMetadata`.
+
+---
+
+## MTDI-03: Client-aware idempotency store/guard + Table Storage re-keying
+
+### User story
+As a **platform engineer responsible for exactly-once processing guarantees**,
+I want **`IdempotencyStatusStore`, `IdempotencyGuard`, `ClaimToken` and both Table services made client-aware, keyed on `(clientId, key)` with a null-clientId legacy fallback**,
+so that **two clients can safely reuse the same `documentId`/`transactionId` without collision, while every existing idempotency guarantee (lease TTL, ETag fencing, terminal-skip, redelivery safety) is preserved bit-for-bit when `clientId` is absent**.
+
+### Background
+FR-6, FR-7, FR-8, NFR-6, DD-5, DD-6. This is the highest-risk story in the initiative (design Risk #1: "broad, mechanical fan-out... easy to miss a call site and break fencing"). Depends on MTDI-01 (`ClientId.requireValid`) and MTDI-02 (`TC_CLIENT_ID` column). The interface signature change (`runOnce(clientId, key, work)`, `ClaimToken(clientId, key, etag)`) is not shippable in smaller independent pieces without leaving the codebase in a broken intermediate state, hence the L size.
+
+### Acceptance criteria
+- [ ] AC-014 (delivers AC-7): Given two clients ingest the same `documentId` (via direct table-service calls in a test harness), when `isDocumentAlreadyProcessed(clientId, documentId)` / `getDocumentById(clientId, documentId)` are called for each, then both rows coexist under distinct partition keys and dedup, overwrite (`supersededDocuments`) and chunk-deletion scoping for one client never touches the other's row.
+- [ ] AC-015 (delivers AC-8): Given a duplicate `runOnce(clientId, key, work)` call against an already-terminal `(clientId, key)` row, when the guard evaluates the row, then `work` is never invoked (no LLM/embedding call, no scoring re-enqueue) — verified for both a real `clientId` and the legacy null-clientId case.
+- [ ] AC-016: Given a null or blank `clientId` passed to any `IdempotencyStatusStore`/table-service method, when the effective partition key is computed, then it falls back to `partitionKey = key` (today's PK==RK==key behaviour), so pre-rollout rows and flag-off callers resolve unchanged.
+- [ ] AC-017: Given a live lease is claimed on `(clientId, key)` and a second delivery arrives for the same client+key, when `claimLease`/`readForClaim` run, then ETag fencing behaves identically to today (412 → `EtagMismatchException` on a reclaimed/expired lease; live-lease rethrow-vs-WARN-at-exhaustion unchanged) — re-verified per client partition.
+- [ ] AC-018: Given the lease-TTL invariant `IDEMPOTENCY_LEASE_TTL_SECONDS < visibilityTimeout × (maxDequeueCount − 1)`, when re-keying is applied, then the invariant and its enforcement are unaffected by the two-part key.
+
+### NFR links
+- NFR-6 (Idempotency): the central concern of this story.
+- NFR-2 (Reversibility): the null-clientId fallback is what makes flag-off behaviour identical to pre-change.
+- NFR-3 (Confidentiality, partial): partition scoping here is the mechanism AC-14 (cross-client 404) later relies on in MTDI-06.
+
+### Out of scope for this story
+- New physical tables / `TableCopier` execution against a live environment (MTDI-07/MTDI-09) — this story only implements the *code* that reads/writes the new keying shape.
+- Wiring worker/function call sites to pass a real, HTTP-resolved `clientId` (MTDI-06).
+- 404 semantics at the HTTP function layer (MTDI-06) — this story only ensures the *store* returns not-found for a cross-partition lookup.
+
+### Definition of done
+- [ ] Code reviewed and approved.
+- [ ] `IdempotencyStatusStore`, `IdempotencyGuard`, `ClaimToken`, `DocumentIngestionOutcomeTableService`, `AnswerGenerationTableService`, `DocumentUploadService.isDocumentAlreadyProcessed` all updated to the `(clientId, key)` signature with null-clientId fallback.
+- [ ] Exhaustive unit coverage on both store implementations and the guard, including the AC-8 regression test explicitly named as such, and a dedicated legacy-fallback test suite (AC-016).
+- [ ] `mvn test -pl ai-document-shared-artefacts,ai-document-ingestion-function,ai-document-answer-retrieval-function,ai-document-metadata-check-function` passes.
+- [ ] `mvn verify` JaCoCo coverage ≥80% on all changed classes (highest regression risk in the initiative — do not under-cover it).
+- [ ] Existing `ai-service-orchestration-test` suite re-run unchanged and green.
+- [ ] SonarQube quality gate passes on the Azure Pipelines PR build.
+- [ ] Explicit sign-off note in the PR description confirming every existing call site of the old `(key)`-only signatures has been migrated (no leftover compile shims) — reviewer must grep for old signatures before approving, per Risk #1.
+
+### Notes / open questions
+- This story alone does not achieve end-to-end AC-7/AC-8 behaviour — it proves the store/guard logic in isolation; MTDI-06 completes the loop.
+- Consider a two-pass review: (1) interface + `IdempotencyGuard`/`ClaimToken`, (2) both Table services — but ship as one story.
+
+---
+
+## MTDI-04: Search filter clause, retrieval threading & reserved-metadata-key rejection
+
+### User story
+As a **consuming client application querying the RAG service**,
+I want **every search query to be scoped by a non-optional, correctly-escaped `clientId` filter clause when enforcement is on, and to be unable to weaken that scoping via `metadataFilter`**,
+so that **I never receive chunks belonging to another client, and cannot accidentally or deliberately widen my own result set to another client's data**.
+
+### Background
+FR-4, FR-5, FR-8 (supersede-scoping side), OQ-2/DD-12. Depends on MTDI-01 (flag var) and MTDI-02 (`IndexConstants.CLIENT_ID`, `ChunkedEntry.clientId`, schema v2 field). The count-variable invariant (`SEARCH_NEAREST_NEIGHBOURS_COUNT ≥ SEARCH_TOP_RESULTS_COUNT > SEARCH_MMR_FINAL_COUNT`) and the containment/dedup/MMR pipeline order are unaffected — the `clientId` clause only narrows the candidate set exactly as a `metadataFilter` does today.
+
+### Acceptance criteria
+- [ ] AC-019 (delivers AC-5): Given a `clientId` and any `metadataFilter` list, when `AzureAISearchService.generateFilterExpression(clientId, metadataFilters)` is called with enforcement on, then the produced OData string begins with a non-optional `clientId eq '<escaped>'` clause ANDed with the rest, using the existing `StringUtil.escapeODataStringLiteral` (no new escaping, DD-3).
+- [ ] AC-020: Given `clientId` is empty/null (flag off), when `generateFilterExpression` is called, then the produced expression is byte-for-byte identical to today's output — the explicit AC-4 regression check at the search-service layer.
+- [ ] AC-021 (delivers AC-6): Given two clients' chunks exist in the same index, when a query with client A's `clientId` runs through `search(clientId, ...)`, then no chunk stamped with a different `clientId` is ever returned, regardless of `metadataFilter` content (component-level; end-to-end version in MTDI-08).
+- [ ] AC-022: Given `getColumnsToRetrieve()`, when a search executes, then `IndexConstants.CLIENT_ID` is included, so `clientId` round-trips into `ChunkedEntry` for downstream consumers.
+- [ ] AC-023: Given ingestion's supersede/deletion path (`DocumentStorageService.getSearchResults`), when it filters existing chunks for a document being overwritten, then the filter is scoped by `clientId eq '<clientId>' and (...)` so client A can never mark client B's chunks inactive.
+- [ ] AC-024: Given a `metadataFilter` entry with `key` in the reserved set (`clientId`, `is_active`), when the answer-retrieval request is validated, then the request is rejected with `400` before any search call is made — **regardless of `CLIENT_FILTERING_ENABLED`** (always-on, stakeholder decision 2026-07-20).
+- [ ] AC-025: Given `CLIENT_FILTERING_ENABLED=false` and a `metadataFilter` containing only non-reserved keys, when the request is validated, then it is accepted and processed exactly as today — the reserved-key rejection is the **single deliberate flag-off behaviour change** in this initiative (see Notes).
+
+### NFR links
+- NFR-4 (Input validation): all `clientId` values reaching an OData literal are escaped via the existing routine.
+- NFR-2 (Reversibility): AC-020 is the explicit regression guarantee.
+
+### Out of scope for this story
+- Threading a real, HTTP-resolved `clientId` into function call sites (MTDI-06).
+- The general `metadataFilter` allow-list (FR-17/OQ-2 full scope) — explicitly deferred; only the minimal reserved-key rejection (DD-12) is in scope.
+- End-to-end integration regression test across real HTTP calls (MTDI-08).
+
+### Definition of done
+- [ ] Code reviewed and approved.
+- [ ] `AzureAISearchService.generateFilterExpression`/`search`/`getColumnsToRetrieve` signatures updated; `DocumentStorageService.getSearchResults` supersede-scoping updated; a small `MetadataFilterValidator` (or equivalent) added for reserved-key rejection.
+- [ ] Unit tests cover AC-019 through AC-025, including an explicit flag-off byte-for-byte regression test (AC-020).
+- [ ] `mvn test -pl ai-document-answer-retrieval-function,ai-document-ingestion-function` passes; `mvn verify` JaCoCo coverage ≥80% on changed classes.
+- [ ] Existing `ai-service-orchestration-test` suite re-run unchanged and green.
+- [ ] SonarQube quality gate passes on the Azure Pipelines PR build.
+- [ ] Confirmed the count-variable invariant documentation in `CLAUDE.md` still holds unchanged (call out explicitly in the PR description).
+
+### Notes / open questions
+- **Resolved (2026-07-20):** the reserved-key rejection is **always-on**, not gated by `CLIENT_FILTERING_ENABLED` — stakeholder decision at story sign-off. This is the initiative's single deliberate flag-off behaviour change: a request whose `metadataFilter` uses the internal keys `clientId`/`is_active` gets 400 even before cut-over. No legitimate caller uses these keys today; the change is defence-in-depth and requires no consumer contract change (`metadataFilter` keys are free-form strings in the spec).
+- The general `metadataFilter` allow-list (OQ-2 full scope) remains an open follow-up; not resolved by this story.
+
+---
+
+## MTDI-05: Blob path prefixing with dual-path (legacy) resolution
+
+### User story
+As a **platform engineer preparing storage for client-namespaced blobs**,
+I want **`DocumentBlobNameResolver` and the blob trigger to support both a new `c={clientId}/…` prefixed shape and the existing legacy flat shape**,
+so that **new client-scoped uploads can be namespaced without breaking retrieval of any already-ingested legacy document**.
+
+### Background
+FR-9, FR-10, NFR-5, DD-8. Depends on MTDI-02 (`QueueIngestionMetadata.clientId` to carry the parsed value onward). The Table row remains the authoritative ownership record — the path is a convenience, never a security boundary.
+
+### Acceptance criteria
+- [ ] AC-026 (delivers AC-9, structural): Given a non-empty `clientId`, when `DocumentBlobNameResolver.getBlobName(clientId, documentId, ext)` is called, then it returns `c={clientId}/{documentId}_{yyyyMMdd}.{ext}`.
+- [ ] AC-027: Given a null/empty `clientId` (flag off or legacy caller), when `getBlobName` is called, then it returns the unchanged flat `{documentId}_{yyyyMMdd}.{ext}` shape — byte-for-byte identical to today.
+- [ ] AC-028 (delivers AC-10): Given a legacy flat-path blob name, when `getDocumentId(blobName)` is called, then it parses correctly via the existing, untouched `BLOB_PATTERN` regex.
+- [ ] AC-029 (delivers AC-10): Given a prefixed blob name, when `getDocumentId(blobName)` and the new `getClientId(blobName)` are called, then they correctly extract `documentId` and `clientId` via a distinct, additive regex branch that does not alter the legacy branch's behaviour.
+- [ ] AC-030: Given a legacy flat blob name, when `getClientId(blobName)` is called, then it returns `null` — signalling "treat as legacy-owned, defer to the Table row for ownership."
+- [ ] AC-031: Given `DocumentBlobTriggerFunction` processing a triggered blob, when it parses the blob name, then it extracts `clientId` from the prefix if present (else `null`), looks up the Table row by the resolved `(clientId, documentId)` pair (using MTDI-03's client-aware table service), and sets `clientId` on the outgoing `QueueIngestionMetadata`.
+
+### NFR links
+- NFR-5 (Backward compatibility): the entire point of this story — verified by AC-027/AC-028/AC-030.
+- NFR-1 (No new infra): same container, a virtual `c=` directory prefix only.
+
+### Out of scope for this story
+- `DocumentUploadFunction` actually calling `getBlobName` with a real, HTTP-resolved `clientId` (MTDI-06).
+- `ChunkUtil` filename methods' invocation with a real `clientId` (MTDI-06) — the parameterised methods themselves are in scope here.
+- Physical migration of legacy blobs or retirement of the dual-path resolver (out of scope for the whole initiative).
+
+### Definition of done
+- [ ] Code reviewed and approved.
+- [ ] `DocumentBlobNameResolver` gains prefixed `getBlobName`, dual-path `getDocumentId`, and new `getClientId`; `ChunkUtil` filename methods gain a `clientId` parameter with the same null-safe fallback; `DocumentBlobTriggerFunction` updated to parse-and-thread `clientId`.
+- [ ] Unit tests cover both blob-name shapes for every resolver method.
+- [ ] `mvn test -pl ai-document-metadata-check-function,ai-document-answer-retrieval-function` passes; `mvn verify` JaCoCo coverage ≥80% on changed classes.
+- [ ] Existing `ai-service-orchestration-test` suite re-run unchanged and green.
+- [ ] SonarQube quality gate passes on the Azure Pipelines PR build.
+- [ ] `BlobClientService.getSasUrl`/`getBlobClient` verified to handle `/`-containing blob names — confirm rather than assume.
+
+### Notes / open questions
+- None outstanding; low-risk, purely additive/parsing logic.
+
+---
+
+## MTDI-06: Wire the five HTTP functions, two queue workers and scorer to client identity
+
+### User story
+As a **consuming client application**,
+I want **the five HTTP endpoints to require and enforce my client identity (when enforcement is on), the async/queue workers and scorer to carry that identity through every retry and redelivery, and cross-client lookups to return 404**,
+so that **my documents, answers and scores are isolated from every other client's, with no existence leakage, and my in-flight requests survive redelivery correctly**.
+
+### Background
+FR-2, FR-7 (call-site half), FR-11, FR-12, FR-13, FR-14. The integration story: first point where a *real, HTTP-resolved* `clientId` flows through the abstractions built in MTDI-01…05. Intentionally the widest-fan-in story; cannot start until all five precede it.
+
+### Acceptance criteria
+- [ ] AC-032 (delivers AC-1, integration): Given enforcement on and a valid `X-Client-Id` header, when any of the five HTTP endpoints is called, then the resolved `clientId` is threaded into the corresponding service call and the request succeeds.
+- [ ] AC-033 (delivers AC-2, integration): Given enforcement on and the header absent/invalid, when any of the five HTTP endpoints is called, then the response is `401` via a shared `HttpResponses.unauthorized(request)` helper, and no downstream processing (no table write, no queue enqueue, no search call) occurs.
+- [ ] AC-034 (delivers AC-3, integration): Given a request body or `metadataFilter` carrying a spoofed clientId-like value, when processed, then only the header-derived value is used end to end (verified via a test asserting the persisted/queried `clientId` matches the header, not the body).
+- [ ] AC-035 (delivers AC-14): Given client B calls `GET /document-upload/{documentReference}` or `GET /answer-user-query-async-status/{transactionId}` for a resource owned by client A, when the lookup runs against `(clientB, id)`, then the response is `404` — never `403`, never `200` with another client's data.
+- [ ] AC-036 (delivers AC-11): Given an async answer request rides queue redelivery up to `maxDequeueCount` (3), when each redelivery attempt runs, then `clientId` is present on every attempt, and `AnswerGenerationFunction.runOnce(payload.clientId(), transactionId, ...)` claims the lease on the correct client-scoped row each time, including citation-guard retries.
+- [ ] AC-037 (delivers AC-12): Given an answer is generated (sync or async), when the `ScoringPayload` blob is written, then it carries `clientId`; when `AnswerScoringFunction` reads it, then it writes the groundedness score back via `recordGroundednessScore(scoringPayload.clientId(), transactionId, score)` — verified for both sync (`transactionId=null`, no table write, unchanged) and async paths.
+- [ ] AC-038 (delivers AC-13): Given scores from two different clients, when `PublishScoreService.publishGroundednessScore(score, userQuery, clientId)` runs, then the published Azure Monitor histogram carries both `query_type` and a new `client_id` attribute, independently queryable per client.
+- [ ] AC-039: Given `CLIENT_FILTERING_ENABLED=false` (or unset), when any of the five endpoints, either worker, or the scorer runs, then behaviour is identical to pre-change: no 401, no filter clause, PK==RK==key, flat blob paths, no `client_id` telemetry dimension (the master flag-off regression check for the whole story).
+- [ ] AC-040: Given `DocumentIngestionFunction`'s worker path, when a message is processed, then `clientId` is threaded from `QueueIngestionMetadata` through `runOnce`, `DocumentIngestionOrchestrator.recordOutcome`, `DocumentChunkingService.createChunkedEntry` (setting `chunk.clientId`), and `DocumentStorageService.uploadChunks` (writing the `clientId` column).
+
+### NFR links
+- NFR-2 (Reversibility): AC-039 is the explicit master regression gate.
+- NFR-3 (Confidentiality): AC-035 is the direct test of "no existence leakage".
+- NFR-4 (Input validation): every worker call site defensively re-validates via `ClientId.requireValid` (MTDI-01) before use.
+- NFR-7 (Contract stability): confirm via the `api-contract-check` skill that no request/response schema in `api-cp-ai-rag` changed.
+
+### Out of scope for this story
+- The migration tool and eval harness (MTDI-07/MTDI-08).
+- The general `metadataFilter` allow-list beyond MTDI-04's reserved-key rejection.
+- Actually flipping `CLIENT_FILTERING_ENABLED=true` in any deployed environment (MTDI-09).
+
+### Definition of done
+- [ ] Code reviewed and approved.
+- [ ] All five HTTP functions adopt the resolver-then-401 pattern; both queue workers and `AnswerScoringFunction` thread `clientId` per the ACs above.
+- [ ] Unit tests for every function/worker cover the positive path, the 401 path, the spoof-resistance path, and — for the two GET functions — the cross-client 404 path.
+- [ ] `mvn test` (all affected modules) passes; `mvn verify` JaCoCo coverage ≥80% on all changed classes.
+- [ ] Integration tests updated/added in `ai-service-orchestration-test` for the enforcement-on paths introduced here (minimal set proving the wiring; the fuller regression matrix lands in MTDI-08) and passing via `./ai-service-orchestration-test/run-integration-test.sh`.
+- [ ] Flag-off regression explicitly re-run and green: the full existing `ai-service-orchestration-test` suite passes unchanged with `CLIENT_FILTERING_ENABLED` unset (AC-039).
+- [ ] SonarQube quality gate passes on the Azure Pipelines PR build.
+- [ ] `Azure/local.settings.sample.json` updated in every touched module with `CLIENT_FILTERING_ENABLED` and `CLIENT_IDENTITY_HEADER` documented (defaults off); root `CLAUDE.md` cross-referenced.
+- [ ] `api-contract-check` skill re-run and confirms no `operationId` request/response schema drift in `api-cp-ai-rag` (NFR-7).
+
+### Notes / open questions
+- Natural point to also verify the count-variable invariant is unaffected in a real end-to-end run (first story where a real `clientId` reaches `search(...)`).
+- Given the size, consider a mid-story checkpoint PR after the two GET functions + 404 semantics land, before tackling the two workers + scorer (higher-risk redelivery/fencing paths).
+
+---
+
+## MTDI-07: Migration-tool `clientIdOverride` + documentation updates
+
+### User story
+As a **release/platform operator**,
+I want **the existing `ai-document-migration-tool`'s index copier extended with a `clientIdOverride` argument (mirroring the table copier's existing `partitionKeyOverride`)**,
+so that **I can stamp the incumbent `clientId` onto the entire existing production corpus (Search documents and Table rows) in one idempotent, resumable pass before enforcement is switched on**.
+
+### Background
+FR-15, FR-16, DD-9. Depends only on MTDI-02 (`ChunkedEntry.clientId`, schema v2 field) — this module is otherwise independent of the function modules, so it can be built in parallel with MTDI-03…06.
+
+### Acceptance criteria
+- [ ] AC-041 (delivers AC-15, tool-level): Given `IndexMigrationTool` is run with a `clientIdOverride` argument, when `IndexCopier.uploadPage` processes each `ChunkedEntry`, then the copy is stamped with `.clientId(override)` before upload, uploads remain idempotent upserts keyed by `id`, and a re-run is safe.
+- [ ] AC-042: Given `clientIdOverride` is blank or `-` (matching the table tool's convention), when the tool runs, then chunks are copied verbatim with no `clientId` stamped (parity with today's copy-only behaviour).
+- [ ] AC-043 (delivers AC-15, resumability): Given the tool is interrupted partway and re-run, when it processes the same source index again, then previously-stamped documents are re-stamped identically (idempotent) and the `clientId eq null` count in the target index continues to converge to 0.
+- [ ] AC-044: Given `TableCopier` already supports `partitionKeyOverride` and requires **no code change**, when it is run twice (once per table) with `partitionKeyOverride=<incumbent clientId>`, then rows are copied into new client-partitioned tables verbatim on all data columns, including stale lease columns, which copy harmlessly since queues are drained (D3) and no live leases exist at migration time.
+- [ ] AC-045: Given the tool's argument parser, when an operator supplies `--help` or omits the new argument, then usage documentation reflects the new `clientIdOverride` option clearly, consistent with the existing documentation style.
+
+### NFR links
+- NFR-1 (No new infra): the tool only stamps/copies within the retained resources.
+- NFR-2 (Reversibility): the migration only *adds* data; old tables/index remain untouched and available for rollback until decommissioned.
+
+### Out of scope for this story
+- Actually running the tool against any live/deployed environment (MTDI-09).
+- The alias repoint (`az rest`) or any cut-over scripting (MTDI-09/runbook).
+- The eval harness's own `.env` changes (MTDI-08).
+
+### Definition of done
+- [ ] Code reviewed and approved.
+- [ ] `IndexMigrationTool` argument parsing and `IndexCopier`/`uploadPage` updated with `clientIdOverride`; `TableMigrationTool`/`TableCopier` verified as needing **no code change** (confirmed by a targeted unit test, not a re-implementation).
+- [ ] Unit tests cover AC-041 through AC-044.
+- [ ] `mvn test -pl ai-document-migration-tool` passes; `mvn verify` JaCoCo coverage ≥80% on changed classes.
+- [ ] No `ai-service-orchestration-test` change required (tool not exercised by that suite).
+- [ ] SonarQube quality gate passes on the Azure Pipelines PR build.
+- [ ] README and `SCHEMA_CHANGES.md` updated with the new `clientIdOverride` argument, its semantics, and a worked example matching the runbook's index-copy step.
+
+### Notes / open questions
+- OQ-4 (incumbent `clientId` value) must be confirmed before this tool is *run* (MTDI-09) — it does not block *building* it.
+- Design Risk #3: confirm per-environment whether the index alias already points at v2; the fallback (in-place field add + stamping pass) is a runbook consideration for MTDI-09, not a code change here.
+
+---
+
+## MTDI-08: Eval harness client scoping + integration-test suite additions
+
+### User story
+As a **QA/platform engineer validating the isolation guarantees before cut-over**,
+I want **the eval harness updated to run against the client-scoped search path, and the integration-test suite extended with a second-client fixture, cross-client 404 checks, a filter-injection regression, and a spoof-resistance test**,
+so that **we have automated, repeatable proof that isolation holds end-to-end before any environment's `CLIENT_FILTERING_ENABLED` flag is flipped**.
+
+### Background
+FR-18, OQ-3/DD-13, AC-6 (end-to-end), AC-14 (end-to-end). Depends on MTDI-06 being merged, and on MTDI-04 for the filter-injection regression specifically.
+
+### Acceptance criteria
+- [ ] AC-046: Given the harness's `.env` gains `EVAL_CLIENT_ID` and `CLIENT_FILTERING_ENABLED=true`, when the harness runs its embed→search→generate→cite pipeline, then it passes `EVAL_CLIENT_ID` into `search(clientId, ...)`, exercising the real filtered path.
+- [ ] AC-047: Given the harness's existing citation/verbosity/coverage metrics, when run against the client-scoped index with `EVAL_CLIENT_ID` set to the incumbent stamped value, then metrics are comparable to pre-change baselines (no unexplained coverage drop attributable to the filter clause).
+- [ ] AC-048: Given `ai-service-orchestration-test`'s request helpers, when any test constructs a request, then an `X-Client-Id` header can be supplied via a shared helper, defaulting to a documented test client fixture.
+- [ ] AC-049: Given a second-client fixture, when a document is ingested for client A and another for client B with the **same `documentId`**, then both ingest successfully and coexist (integration-level proof of AC-7).
+- [ ] AC-050 (delivers AC-14, integration): Given client B polls/queries a `documentReference`/`transactionId` created by client A, when the request completes, then the response is `404`.
+- [ ] AC-051 (delivers AC-6, integration): Given both clients' documents are ingested and a query is run scoped to client A with a broad/no `metadataFilter`, when results are returned, then no chunk belonging to client B appears (full end-to-end filter-injection regression).
+- [ ] AC-052 (delivers AC-3, integration): Given a request with a spoofed `clientId`-shaped value inside `metadataFilter` or the request body, when processed, then the response reflects only the header-derived identity, and the spoofed value has zero effect on returned data.
+
+### NFR links
+- NFR-3 (Confidentiality): AC-050/AC-051 are the acceptance-level proof of no existence/data leakage.
+- NFR-5 (Backward compatibility): harness changes must not break existing single-client eval runs with the flag off.
+- NFR-6 (Idempotency): the second-client duplicate-documentId fixture is a natural place to assert AC-8 end-to-end if a redelivery is simulated.
+
+### Out of scope for this story
+- Any change to the harness's core evaluation logic beyond threading `clientId` into the search call.
+- Running the harness or integration suite against a cut-over production environment (MTDI-09 validation).
+
+### Definition of done
+- [ ] Code reviewed and approved.
+- [ ] `ai-document-system-prompt-harness-eval/.env.sample` updated with `EVAL_CLIENT_ID` and `CLIENT_FILTERING_ENABLED`; harness search invocation updated.
+- [ ] `ai-service-orchestration-test` request helpers updated with header injection; second-client fixture added; new tests for cross-client 404, filter-injection regression, and spoof resistance added.
+- [ ] `mvn test` passes for touched modules; harness changes verified via its own `run-harness.sh` (documented run — the harness is offline/on-demand).
+- [ ] Full integration-test run via `./ai-service-orchestration-test/run-integration-test.sh` passes, including all new client-isolation tests.
+- [ ] `mvn verify` JaCoCo coverage maintained on any production code touched incidentally (expected none/minimal).
+- [ ] SonarQube quality gate passes on the Azure Pipelines PR build.
+- [ ] Harness metrics comparison (AC-047) recorded as evidence.
+
+### Notes / open questions
+- OQ-3 is resolved by this story's approach (DD-13) — confirm it satisfies the eval team's expectations before closing OQ-3.
+- If AC-047 shows any metrics regression, investigate whether it's the filter clause narrowing recall versus an unrelated cause — don't silently absorb a coverage drop.
+
+---
+
+## MTDI-09: [OPS — NOT A CODE STORY] Per-environment cut-over runbook execution
+
+### User story
+As a **release/platform operator**,
+I want **to execute the documented cut-over runbook (quiesce → drain queues → migrate index+tables → repoint alias/tables → flip `CLIENT_FILTERING_ENABLED` → resume) once per environment**,
+so that **each environment's existing corpus is safely stamped with the incumbent `clientId` and enforcement is switched on with zero data loss and a clean rollback path**.
+
+### Background
+FR-16, D3, DD-11, design §F runbook and Diagram 3. **Explicitly not a development story** — operational execution of tooling and config delivered by MTDI-06/07/08, run per environment (lower environments first) by the release operator with the dev team on standby.
+
+### Acceptance criteria
+- [ ] AC-053 (delivers AC-16): Given write traffic is quiesced and queues (ingestion, answer-generation, scoring) are drained, when the operator checks queue depth and in-flight idempotency leases, then zero in-flight messages and zero live leases are confirmed before migration starts.
+- [ ] AC-054: Given the operator runs the index-copy tool with `clientIdOverride=<incumbent clientId>` (OQ-4 resolved), when the run completes, then the `clientId eq null` count in the target index reaches 0.
+- [ ] AC-055: Given the operator runs the table-copy tool for both tables with `partitionKeyOverride=<incumbent clientId>`, when the run completes and a final idempotent re-copy is executed immediately before the flag flip, then no rows are missed from writes that landed between the initial copy and the flip.
+- [ ] AC-056: Given the index alias and table env vars are repointed and `CLIENT_FILTERING_ENABLED=true`, when traffic resumes, then a smoke test against each of the five endpoints (using the MTDI-08 suite or a subset) confirms enforcement is active (401 without header, 404 cross-client, correct filtering).
+- [ ] AC-057: Given a rollback is triggered, when the operator flips the flag off and repoints table env vars to the old (untouched) tables, then the service returns to pre-cutover behaviour with **no data rewrite** (the alias may safely remain on v2, per DD-11).
+
+### NFR links
+- NFR-2 (Reversibility): AC-057 is the direct operational proof.
+- NFR-1 (No new infra): confirm no new Azure resources beyond the new tables covered by the "single logical set post-migration" interpretation.
+- NFR-6 (Idempotency): AC-053/AC-055 confirm no idempotency regression during the migration window.
+
+### Out of scope for this story
+- Any code change — a bug found during the runbook is a new, separate bug-fix story.
+- APIM policy deployment (`cpp-azure-api-management`) — coordination dependency; this story assumes the header-injection policy is live in the target environment before enforcement flips.
+- Physical retirement of old tables/index or the dual-path blob resolver.
+
+### Definition of done
+- [ ] Runbook executed and checked off step-by-step against design §F / Diagram 3, with each step's evidence (queue depths, `clientId eq null` count, row counts pre/post copy) attached to the environment's change record.
+- [ ] Post-cutover smoke test (AC-056) passed and evidenced.
+- [ ] Rollback procedure (AC-057) dry-run-verified in at least one lower environment before production execution.
+- [ ] OQ-1 (clientId format) and OQ-4 (incumbent clientId value) confirmed and recorded before this story starts in any environment.
+- [ ] Sign-off recorded from platform/release operator and tech lead per environment.
+
+### Notes / open questions
+- Run once per environment, lower environments first. Do not run in production until at least one lower environment has completed the full cycle including a rollback dry-run.
+- Design Risk #3: confirm per-environment whether `AZURE_SEARCH_SERVICE_INDEX_NAME` already resolves to a v2 alias; if so, use the in-place-field-add fallback (design §B option iii) — changes the runbook's index step only.

--- a/docs/pipeline/adrs/0001-logical-multi-client-isolation-via-clientid-namespace.md
+++ b/docs/pipeline/adrs/0001-logical-multi-client-isolation-via-clientid-namespace.md
@@ -1,0 +1,66 @@
+# ADR 0001: Logical multi-client isolation via a single `clientId` namespace
+
+| | |
+|---|---|
+| **Status** | Proposed (pending tech-lead sign-off) |
+| **Date** | 2026-07-20 |
+| **Jira** | DD-42722 (sub-tasks DD-42976 … DD-42984) |
+| **Artefacts** | `docs/pipeline/DD-42722-multi-tenant-data-isolation/` (00-input-brief, 01-requirements, 02-design, 03-stories) |
+| **Supersedes / superseded by** | — |
+
+## Context
+
+The CP AI RAG Service is single-consumer by construction: APIM validates one Entra ID application's JWT and the function backends receive no caller identity. All ingested documents, AI Search chunks, Table Storage rows and blobs share one namespace, so any caller holding a UUID (`documentReference` / `transactionId`) can read any other caller's status or answer payload. The service must onboard multiple clients (HMCTS-internal teams and external partners) with per-client data isolation.
+
+Constraints shaping the decision:
+
+- **No new infrastructure resources** — the single AI Search index, storage account and set of tables are retained.
+- **The upstream consumer-identity mechanism (AMP / API Marketplace) is owned by another team and not yet concrete** — the backend may receive a header today, a JWT or cookie later.
+- **An existing single-client production corpus** must be migrated, not orphaned, and a hand-run migration module (`ai-document-migration-tool`) already exists: an index→index copier (pending v2 schema rebuild with alias cutover) and a table→table copier with `partitionKeyOverride`.
+- **Reversibility** — cut-over must be roll-back-able without a data rewrite.
+- The recently-landed **idempotency guard** leases and fences on the very table rows whose keying this decision changes.
+
+## Decision
+
+Adopt **logical isolation** with a single `clientId` attribute (UUID, validated at the boundary) threaded through every data path, enforced behind a feature flag:
+
+1. **Identity at the edge, abstracted once.** APIM (per AMP standards) identifies the consumer and passes it downstream; the backend reads it through one shared abstraction — `ClientIdentityResolver` / `ClientContext` in `ai-document-shared-artefacts` (header-based default, header name configurable via `CLIENT_IDENTITY_HEADER`). This is the single point of change when AMP finalises. The header is an **internal APIM↔function contract**, not part of the consumer OpenAPI spec. Missing/invalid identity → 401 when enforcement is on.
+2. **`clientId` as the namespace everywhere in the data plane:**
+   - AI Search: top-level filterable (non-searchable) `clientId` field, added to the pending **v2** schema rebuild; a non-optional leading `clientId eq '…'` OData clause on every query and on the ingestion supersede/delete filter.
+   - Table Storage: partition key = `clientId`, row key = `documentId`/`transactionId` (new tables populated by the existing table copier; env vars repointed at cut-over). The idempotency store/guard becomes client-aware (`(clientId, key)`), preserving all lease/fencing semantics; null clientId falls back to today's PK==RK==key.
+   - Blobs: new blobs prefixed `c={clientId}/…` with a dual-path resolver for legacy flat names; the Table row — not the path — is the authoritative ownership record.
+   - Queues: `clientId` is a non-optional payload field (and rides the `ScoringPayload` blob for the scorer), so it survives redelivery.
+   - Telemetry: a `client_id` metric dimension.
+3. **Enforcement behind `CLIENT_FILTERING_ENABLED`** (default off = byte-for-byte today's behaviour). The single deliberate exception: rejection of reserved `metadataFilter` keys (`clientId`, `is_active` → 400) is **always-on**.
+4. **Cross-client lookups return 404** (never 403) as a natural consequence of partition scoping — no existence leakage.
+5. **`documentId` uniqueness is per client** — two clients may reuse the same id without collision (chunk ids are random UUIDs, so no index key collision).
+6. **Migration** extends the existing tool: a `clientIdOverride` on the index copier (analogue of the table copier's `partitionKeyOverride`) stamps the incumbent client during the single v2 rebuild. Cut-over is per environment with **drained queues** (no dual-write): quiesce → drain → migrate → final idempotent table re-copy → repoint alias + table env vars → flip flag → resume.
+
+## Alternatives considered
+
+- **Index-per-client** (one AI Search index per client, dynamic index resolution): removes the filter-bypass vulnerability class entirely, but multiplies index lifecycle (schema upgrades, capacity, tuning, cost attribution) by N and runs into per-SKU index caps. Rejected as the starting point.
+- **Full silo** (function app + storage + search + OpenAI per client): maximal isolation, cost and operational overhead proportional to tenant count; only justified by regulation or extreme noisy-neighbour concerns that do not apply. Rejected.
+- **Reusing `customMetadata` for tenancy**: co-locates tenancy with caller-controlled data, conflating trust boundaries. Rejected in favour of a top-level field.
+- **Dual-write transition mode** instead of drained-queue cut-over: more machinery for a window the queue drain eliminates. Rejected.
+- **Per-function header parsing** instead of one shared resolver: no single point of change when AMP finalises. Rejected.
+
+The full decision list (design decisions 1–13, with per-decision alternatives) is in `02-design.md`.
+
+## Consequences
+
+**Positive**
+- Isolation with zero new infrastructure; onboarding a new client is APIM configuration only.
+- `clientId`-as-namespace preserves the option to migrate an individual client to its own index or full silo later via routing/config only.
+- Flag + table-env-var rollback requires no data rewrite; old tables and v1 index stay untouched through the reversibility window.
+- Every merge before cut-over is behaviour-neutral (flag off), so delivery is incremental and low-risk.
+
+**Negative / accepted risks**
+- **One-way doors:** (a) the partition-key choice — once clients depend on `(clientId, key)` keying, un-isolating requires another migration; (b) the index alias repoint — harmless to leave on v2 during rollback, but the v1 index becomes stale the moment post-cutover ingestion begins.
+- Isolation correctness depends on the leading OData clause and partition scoping being applied on **every** path — a broad mechanical fan-out (idempotency store, both table services, both workers) that must be regression-tested exhaustively (the highest-risk story, MTDI03/DD-42978).
+- A compromised or misconfigured APIM layer defeats edge identity; mitigated by function-key + network restriction and the always-on reserved-key rejection, but the backend ultimately trusts the injected identity.
+- Per-client metric cardinality grows linearly with onboarded clients (bounded, acceptable).
+
+**Follow-ups**
+- Coordination dependency: `cpp-azure-api-management` must inject the header matching `CLIENT_IDENTITY_HEADER` before production enforcement.
+- Open before cut-over: final `clientId` format confirmation (UUID assumed) and the incumbent client's concrete value (migration-tool argument).
+- Deferred: general `metadataFilter` allow-list; legacy blob retirement; per-client rate limits/quotas (AMP).

--- a/docs/pipeline/adrs/0001-logical-multi-client-isolation-via-clientid-namespace.md
+++ b/docs/pipeline/adrs/0001-logical-multi-client-isolation-via-clientid-namespace.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | Proposed (pending tech-lead sign-off) |
+| **Status** | Accepted (2026-07-20, Mahesh Subramanian) |
 | **Date** | 2026-07-20 |
 | **Jira** | DD-42722 (sub-tasks DD-42976 … DD-42984) |
 | **Artefacts** | `docs/pipeline/DD-42722-multi-tenant-data-isolation/` (00-input-brief, 01-requirements, 02-design, 03-stories) |


### PR DESCRIPTION
**Jira:** DD-42722

Documentation only — no code changes.

Adds the SDLC pipeline artefacts for the multi-client data isolation initiative under `docs/pipeline/DD-42722-multi-tenant-data-isolation/`:

- **00-input-brief.md** — consolidated input: corrected Confluence strategy (page 1973297793), verified codebase state, stakeholder decisions (clientId naming, per-client documentId uniqueness, drained-queue cut-over, AMP identity abstraction, internal header contract)
- **01-requirements.md** — approved requirements: 18 FRs, 7 NFRs, 16 acceptance criteria, open questions
- **02-design.md** — approved design: client-identity abstraction, clientId in the pending v2 index rebuild, client-aware idempotency/table re-keying, blob dual-path strategy, queue/scoring threading, migration & cut-over runbook, 13 design decisions with alternatives, Mermaid diagrams
- **03-stories.md** — 9 stories (phased, each mergeable flag-off) mapped to Jira sub-tasks DD-42976..DD-42984

Plus **docs/pipeline/adrs/0001** — accepted ADR: logical multi-client isolation via a single clientId namespace behind `CLIENT_FILTERING_ENABLED`, with alternatives considered and one-way doors.

These documents are the source of truth referenced by the nine Jira sub-tasks; merging fixes their GitHub links.