### PR TITLE
feat: index-copier clientIdOverride for the multi-client migration

### DIFF
--- a/ai-document-migration-tool/README.md
+++ b/ai-document-migration-tool/README.md
@@ -94,7 +94,8 @@ mvn -pl ai-document-migration-tool exec:java \
   -Dexec.args="index https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 8 20000"
 
 # Multi-client migration: full copy that also stamps every chunk with the incumbent client id
-# (positional arg 9 — pass "-" for any earlier optional slot you want to leave at its default)
+# (positional arg 9 — supply explicit workers/maxRecords values to reach it; the resume-cursor
+#  slot may be "-" since it is ignored for multi-worker runs)
 mvn -pl ai-document-migration-tool exec:java \
   -Dexec.args="index https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 8 0 - 8f7b1c2e-4a5d-4f6e-9b0a-1c2d3e4f5a6b"
 

--- a/ai-document-migration-tool/README.md
+++ b/ai-document-migration-tool/README.md
@@ -81,7 +81,7 @@ The `index` subcommand selects this tool; everything after it is the index tool'
 
 ```bash
 mvn -pl ai-document-migration-tool exec:java \
-  -Dexec.args="index <endpoint> <sourceIndex> <targetIndex> <aliasName> <schemaResourcePath> [workers] [maxRecords] [startAfterId]"
+  -Dexec.args="index <endpoint> <sourceIndex> <targetIndex> <aliasName> <schemaResourcePath> [workers] [maxRecords] [startAfterId] [clientIdOverride]"
 ```
 
 ```bash
@@ -92,6 +92,11 @@ mvn -pl ai-document-migration-tool exec:java \
 # Sample copy of the first 20,000 records (validation) — no verification, no cutover command
 mvn -pl ai-document-migration-tool exec:java \
   -Dexec.args="index https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 8 20000"
+
+# Multi-client migration: full copy that also stamps every chunk with the incumbent client id
+# (positional arg 9 — pass "-" for any earlier optional slot you want to leave at its default)
+mvn -pl ai-document-migration-tool exec:java \
+  -Dexec.args="index https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 8 0 - 8f7b1c2e-4a5d-4f6e-9b0a-1c2d3e4f5a6b"
 
 # Low-memory / constrained host: sync uploads, 4 workers, heap capped at 1 GB
 MAVEN_OPTS="-Xmx1g -XX:+UseG1GC" \
@@ -115,6 +120,7 @@ These are the `index` tool's arguments (they follow the `index` subcommand).
 | 6 | `workers` | no | `8` | Concurrent shard readers; effective parallelism is `min(workers, 16)` |
 | 7 | `maxRecords` | no | `0` (all) | Global cap on documents copied — a positive value makes it a **sample** run |
 | 8 | `startAfterId` | no | — | Resume cursor (single-worker runs only; ignored when `workers > 1`) |
+| 9 | `clientIdOverride` | no | — | Stamps every copied chunk's `clientId` with this value (the multi-client migration). Omit, or pass blank / `-`, to copy chunks **verbatim**. Re-runs re-stamp identically — uploads stay idempotent upserts keyed by `id`. |
 
 Read page size and the async initial batch size are fixed at **250** (`DEFAULT_PAGE_SIZE`) — a 3072-float
 vector serialises to ~25–35 KB of JSON, so 250 keeps a batch (~7–9 MB) safely under Azure's 16 MB request

--- a/ai-document-migration-tool/SCHEMA_CHANGES.md
+++ b/ai-document-migration-tool/SCHEMA_CHANGES.md
@@ -35,6 +35,10 @@ tool does.
 - **`synonymMaps` removed** from every field except `chunk` (they only apply to searchable string fields).
 - **Unchanged:** `chunkVector` (incl. `dimensions`), `retrievable`, `stored`, and the vector (HNSW),
   semantic, and similarity (BM25) configuration.
+- **New `clientId` field** — a top-level consumer-namespace field (`filterable`, not `searchable`) for
+  multi-client data isolation. Source (v1) documents have no value for it; the migration stamps it onto
+  every copied chunk when the index tool is run with the `clientIdOverride` argument (see the README's
+  argument table), so the rebuilt index comes up fully attributed to the incumbent client.
 
 ---
 
@@ -53,6 +57,7 @@ the vector, back out). ✅ = enabled in v2, ❌ = disabled in v2; **bold** marks
 | `pageNumber` | `Edm.Int32` | ❌ | **❌** | **❌** | **❌** | Retrieved only; dropped unused filter/sort/facet. |
 | `chunkIndex` | `Edm.Int32` | ❌ | **❌** | **❌** | **❌** | Retrieved only; dropped unused filter/sort/facet. |
 | `documentFileUrl` | `Edm.String` | **❌** | **❌** | **❌** | **❌** | Citation field, retrieved only; dropped searchable/filter/sort/facet. |
+| `clientId` | `Edm.String` | ❌ | ✅ | ❌ | ❌ | **New in v2.** Top-level consumer namespace for multi-client isolation; filtered on every query once enforcement is enabled. Populated during migration via the index tool's `clientIdOverride`. |
 | `customMetadata/key` | `Edm.String` (complex) | **❌** | ✅ | ❌ | **❌** | Kept `filterable` (drives the `/any(...)` metadata filters); dropped searchable/facetable. |
 | `customMetadata/value` | `Edm.String` (complex) | **❌** | ✅ | ❌ | **❌** | Kept `filterable` (drives the `/any(...)` metadata filters); dropped searchable/facetable. |
 

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/MigrationTool.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/MigrationTool.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
  * or unrecognised tool name prints the usage (listing both tools and their argument signatures) and fails.</p>
  *
  * <pre>
- *   index  &lt;endpoint&gt; &lt;sourceIndex&gt; &lt;targetIndex&gt; &lt;aliasName&gt; &lt;schemaResourcePath&gt; [workers] [maxRecords] [startAfterId]
+ *   index  &lt;endpoint&gt; &lt;sourceIndex&gt; &lt;targetIndex&gt; &lt;aliasName&gt; &lt;schemaResourcePath&gt; [workers] [maxRecords] [startAfterId] [clientIdOverride]
  *   table  &lt;sourceTable&gt; &lt;targetTable&gt; [partitionKeyOverride] [maxRecords]
  *
  *   # via the packaged jar / container (ENTRYPOINT is "java -jar app.jar")
@@ -33,7 +33,7 @@ public final class MigrationTool {
 
     private static final String USAGE = """
             Usage: <tool> <tool-args...>  (no default — name the tool explicitly)
-              index  <endpoint> <sourceIndex> <targetIndex> <aliasName> <schemaResourcePath> [workers] [maxRecords] [startAfterId]
+              index  <endpoint> <sourceIndex> <targetIndex> <aliasName> <schemaResourcePath> [workers] [maxRecords] [startAfterId] [clientIdOverride]
               table  <sourceTable> <targetTable> [partitionKeyOverride] [maxRecords]""";
 
     private MigrationTool() {

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/IndexCopier.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/IndexCopier.java
@@ -183,8 +183,23 @@ final class IndexCopier {
         if (clientIdOverride == null) {
             return entries; // no override — copy verbatim
         }
-        // Override configured; stamping the clientId onto each copy is not yet applied here.
-        return entries;
+        return entries.stream().map(this::withClientId).toList();
+    }
+
+    /** Copies an entry with the configured clientId set and every other field preserved. */
+    private ChunkedEntry withClientId(final ChunkedEntry source) {
+        return ChunkedEntry.builder()
+                .id(source.id())
+                .documentId(source.documentId())
+                .chunk(source.chunk())
+                .chunkVector(source.chunkVector())
+                .documentFileName(source.documentFileName())
+                .pageNumber(source.pageNumber())
+                .chunkIndex(source.chunkIndex())
+                .documentFileUrl(source.documentFileUrl())
+                .customMetadata(source.customMetadata())
+                .clientId(clientIdOverride)
+                .build();
     }
 
     private void recordSkips(final long pageSkipped, final String label) {

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/IndexCopier.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/IndexCopier.java
@@ -51,6 +51,8 @@ final class IndexCopier {
     private final int pageSize;
     private final int workers;
     private final long maxRecords; // <= 0 means copy everything; otherwise a global cap (sample copy)
+    /** Fixed clientId stamped onto every copied chunk before upload, or {@code null} to copy verbatim. */
+    private final String clientIdOverride;
 
     // Shared across worker threads for aggregate progress / ETA.
     private final AtomicLong submitted = new AtomicLong();
@@ -59,16 +61,27 @@ final class IndexCopier {
     private long baseProcessed;  // docs already copied before this run (resume), for the ETA
     private long startNanos;     // set before workers start -> happens-before via task submission
 
+    /** Convenience constructor for a verbatim copy — no clientId is stamped onto the copies. */
     IndexCopier(final SearchClient source,
                 final DocumentUploader uploader,
                 final int pageSize,
                 final int workers,
                 final long maxRecords) {
+        this(source, uploader, pageSize, workers, maxRecords, null);
+    }
+
+    IndexCopier(final SearchClient source,
+                final DocumentUploader uploader,
+                final int pageSize,
+                final int workers,
+                final long maxRecords,
+                final String clientIdOverride) {
         this.source = source;
         this.uploader = uploader;
         this.pageSize = pageSize;
         this.workers = Math.max(1, workers);
         this.maxRecords = maxRecords;
+        this.clientIdOverride = clientIdOverride;
     }
 
     private boolean limited() {
@@ -154,11 +167,24 @@ final class IndexCopier {
         }
         final long take = claim(valid.size()); // bumps submitted; trims to the remaining cap when limited
         if (take > 0) {
+            final List<ChunkedEntry> claimed = take == valid.size() ? valid : valid.subList(0, (int) take);
             // The uploader is either async (buffered sender) or sync (per-page, memory-bounded); either way a
             // transient per-doc error is counted, not fatal.
-            uploader.upload(take == valid.size() ? valid : valid.subList(0, (int) take));
+            uploader.upload(stampForUpload(claimed));
         }
         return take < valid.size();
+    }
+
+    /**
+     * Maps the claimed slice to the entries handed to the uploader. When a fixed clientId is configured each
+     * entry is copied with that value set; with no override configured the entries are copied verbatim.
+     */
+    private List<ChunkedEntry> stampForUpload(final List<ChunkedEntry> entries) {
+        if (clientIdOverride == null) {
+            return entries; // no override — copy verbatim
+        }
+        // Override configured; stamping the clientId onto each copy is not yet applied here.
+        return entries;
     }
 
     private void recordSkips(final long pageSkipped, final String label) {

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/IndexMigrationTool.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/IndexMigrationTool.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * <p>Usage (managed-identity / {@code az login} credential is used automatically):</p>
  * <pre>
  *   mvn -pl ai-document-migration-tool exec:java \
- *     -Dexec.args="&lt;endpoint&gt; &lt;sourceIndex&gt; &lt;targetIndex&gt; &lt;aliasName&gt; &lt;schemaResourcePath&gt; [workers] [maxRecords] [startAfterId]"
+ *     -Dexec.args="&lt;endpoint&gt; &lt;sourceIndex&gt; &lt;targetIndex&gt; &lt;aliasName&gt; &lt;schemaResourcePath&gt; [workers] [maxRecords] [startAfterId] [clientIdOverride]"
  *
  *   # full copy, 8 concurrent shards
  *   ... -Dexec.args="https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 8"
@@ -49,6 +49,9 @@ import org.slf4j.LoggerFactory;
  *   # sample copy of the first 20000 records, 8 workers
  *   ... -Dexec.args="https://my-svc.search.windows.net ai-rag-service-index ai-rag-service-index-v2 ai-rag-service-index-alias /vector-db-index-schema-v2.json 8 20000"
  * </pre>
+ *
+ * <p>{@code clientIdOverride} is optional; omit it (or pass a blank / {@code "-"}) to copy chunks verbatim.
+ * When supplied, every copied chunk is stamped with that fixed clientId before upload.</p>
  */
 public final class IndexMigrationTool {
 
@@ -68,7 +71,7 @@ public final class IndexMigrationTool {
     public static void main(final String[] args) throws Exception {
         if (args.length < 5) {
             throw new IllegalArgumentException("Usage: <endpoint> <sourceIndex> <targetIndex> <aliasName> "
-                    + "<schemaResourcePath> [workers] [maxRecords] [startAfterId]");
+                    + "<schemaResourcePath> [workers] [maxRecords] [startAfterId] [clientIdOverride]");
         }
         final String endpoint = args[0];
         final String sourceIndex = args[1];
@@ -78,6 +81,9 @@ public final class IndexMigrationTool {
         final int workers = args.length > 5 ? Integer.parseInt(args[5]) : DEFAULT_WORKERS;
         final long maxRecords = args.length > 6 ? Long.parseLong(args[6]) : 0; // 0 = copy everything
         final String startAfterId = args.length > 7 ? args[7] : null;
+        // Treat a blank arg or the "-" placeholder as "no override" so the copies are made verbatim.
+        final String clientIdOverride =
+                args.length > 8 && !args[8].isBlank() && !"-".equals(args[8]) ? args[8] : null;
 
         final SearchIndexClient indexClient = SearchIndexAdmin.indexClient(endpoint);
         SearchIndexAdmin.createTargetIndex(indexClient, targetIndex, schemaResource);
@@ -90,7 +96,7 @@ public final class IndexMigrationTool {
 
         final long submitted;
         try {
-            submitted = new IndexCopier(sourceClient, uploader, DEFAULT_PAGE_SIZE, workers, maxRecords)
+            submitted = new IndexCopier(sourceClient, uploader, DEFAULT_PAGE_SIZE, workers, maxRecords, clientIdOverride)
                     .copyAllDocuments(startAfterId);
         } finally {
             uploader.close(); // flush/await (async) or no-op (sync)

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/IndexMigrationTool.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/IndexMigrationTool.java
@@ -84,6 +84,9 @@ public final class IndexMigrationTool {
         // Treat a blank arg or the "-" placeholder as "no override" so the copies are made verbatim.
         final String clientIdOverride =
                 args.length > 8 && !args[8].isBlank() && !"-".equals(args[8]) ? args[8] : null;
+        LOGGER.info("Index copy starting — source='{}', target='{}', clientIdOverride={}.",
+                sourceIndex, targetIndex,
+                clientIdOverride == null ? "(none — copy verbatim)" : "'" + clientIdOverride + "'");
 
         final SearchIndexClient indexClient = SearchIndexAdmin.indexClient(endpoint);
         SearchIndexAdmin.createTargetIndex(indexClient, targetIndex, schemaResource);

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/index/IndexCopierTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/index/IndexCopierTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import uk.gov.moj.cp.ai.model.ChunkedEntry;
+import uk.gov.moj.cp.ai.model.KeyValuePair;
 
 import java.util.Collections;
 import java.util.List;
@@ -156,11 +157,106 @@ class IndexCopierTest {
         verify(source).search(any(), any(), any()); // resume count query executed (countProcessedBefore)
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    void copyAllDocumentsStampsEveryUploadedChunkWithTheConfiguredClientIdWhenOverrideSet() {
+        final DocumentUploader uploader = mock(DocumentUploader.class);
+        final String override = "consumer-abc";
+        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), uploader, 5, 1, 0, override));
+
+        final ChunkedEntry source1 = populatedChunk("id-1");
+        final ChunkedEntry source2 = populatedChunk("id-2");
+        doReturn(List.of(source1, source2)).when(copier).readPage(any(), any());
+
+        copier.copyAllDocuments(null);
+
+        final ArgumentCaptor<List<ChunkedEntry>> uploaded = ArgumentCaptor.forClass(List.class);
+        verify(uploader).upload(uploaded.capture());
+        // The copy carries the override clientId; every other field is unchanged from the source (record equality).
+        assertThat(uploaded.getValue())
+                .allSatisfy(entry -> assertThat(entry.clientId()).isEqualTo(override))
+                .containsExactly(withClientId(source1, override), withClientId(source2, override));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void copyAllDocumentsLeavesClientIdUntouchedWhenNoOverrideConfigured() {
+        final DocumentUploader uploader = mock(DocumentUploader.class);
+        // Convenience constructor (no override) — the pre-existing verbatim copy behaviour.
+        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), uploader, 5, 1, 0));
+
+        final ChunkedEntry source1 = populatedChunk("id-1");
+        doReturn(List.of(source1)).when(copier).readPage(any(), any());
+
+        copier.copyAllDocuments(null);
+
+        final ArgumentCaptor<List<ChunkedEntry>> uploaded = ArgumentCaptor.forClass(List.class);
+        verify(uploader).upload(uploaded.capture());
+        assertThat(uploaded.getValue()).containsExactly(source1); // verbatim
+        assertThat(uploaded.getValue().get(0).clientId()).isNull();
+    }
+
+    @Test
+    void copyAllDocumentsStampsTheSamePageIdenticallyOnEveryRun() {
+        final String override = "consumer-abc";
+        final ChunkedEntry source1 = populatedChunk("id-1");
+        final ChunkedEntry source2 = populatedChunk("id-2");
+
+        final List<ChunkedEntry> firstRun = uploadedFor(override, List.of(source1, source2));
+        final List<ChunkedEntry> secondRun = uploadedFor(override, List.of(source1, source2));
+
+        // Re-processing the same page yields byte-identical stamped copies, so a re-run is a safe idempotent upsert.
+        assertThat(firstRun).isEqualTo(secondRun);
+        assertThat(firstRun).containsExactly(withClientId(source1, override), withClientId(source2, override));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<ChunkedEntry> uploadedFor(final String override, final List<ChunkedEntry> page) {
+        final DocumentUploader uploader = mock(DocumentUploader.class);
+        final IndexCopier copier = spy(new IndexCopier(mock(SearchClient.class), uploader, 5, 1, 0, override));
+        doReturn(page).when(copier).readPage(any(), any());
+        copier.copyAllDocuments(null);
+        final ArgumentCaptor<List<ChunkedEntry>> uploaded = ArgumentCaptor.forClass(List.class);
+        verify(uploader).upload(uploaded.capture());
+        return uploaded.getValue();
+    }
+
     private static ChunkedEntry chunk(final String id) {
         return chunkWithVector(id, Collections.nCopies(IndexCopier.VECTOR_DIMENSIONS, 0.0f));
     }
 
     private static ChunkedEntry chunkWithVector(final String id, final List<Float> vector) {
         return ChunkedEntry.builder().id(id).chunkVector(vector).build();
+    }
+
+    /** A chunk with every field populated, a valid-size vector, and no clientId set (as a legacy source row). */
+    private static ChunkedEntry populatedChunk(final String id) {
+        return ChunkedEntry.builder()
+                .id(id)
+                .documentId("doc-" + id)
+                .chunk("content of " + id)
+                .chunkVector(Collections.nCopies(IndexCopier.VECTOR_DIMENSIONS, 0.1f))
+                .documentFileName("file-" + id + ".pdf")
+                .pageNumber(2)
+                .chunkIndex(4)
+                .documentFileUrl("https://store/file-" + id + ".pdf")
+                .customMetadata(List.of(new KeyValuePair("k", "v")))
+                .build();
+    }
+
+    /** The source chunk with only its clientId replaced — every other field preserved. */
+    private static ChunkedEntry withClientId(final ChunkedEntry source, final String clientId) {
+        return ChunkedEntry.builder()
+                .id(source.id())
+                .documentId(source.documentId())
+                .chunk(source.chunk())
+                .chunkVector(source.chunkVector())
+                .documentFileName(source.documentFileName())
+                .pageNumber(source.pageNumber())
+                .chunkIndex(source.chunkIndex())
+                .documentFileUrl(source.documentFileUrl())
+                .customMetadata(source.customMetadata())
+                .clientId(clientId)
+                .build();
     }
 }

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/index/IndexMigrationToolTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/index/IndexMigrationToolTest.java
@@ -16,6 +16,7 @@ import uk.gov.moj.cp.ai.client.AISearchClientFactory;
 import uk.gov.moj.cp.ai.model.ChunkedEntry;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -40,6 +41,29 @@ class IndexMigrationToolTest {
         assertThatThrownBy(() -> IndexMigrationTool.main(new String[]{"a", "b", "c", "d"}))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Usage:");
+    }
+
+    @Test
+    void usageMessageDocumentsTheClientIdOverrideArgument() {
+        assertThatThrownBy(() -> IndexMigrationTool.main(new String[]{"a", "b", "c"}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("clientIdOverride");
+    }
+
+    @Test
+    void clientIdOverrideArgumentIsParsedAndThreadedOntoTheCopier() throws Exception {
+        assertThat(copierClientIdOverrideArg("8", "0", "cursor-x", "consumer-abc")).isEqualTo("consumer-abc");
+    }
+
+    @Test
+    void blankOrDashClientIdOverrideArgumentIsTreatedAsNoOverride() throws Exception {
+        assertThat(copierClientIdOverrideArg("8", "0", "cursor-x", "-")).isNull();
+        assertThat(copierClientIdOverrideArg("8", "0", "cursor-x", " ")).isNull();
+    }
+
+    @Test
+    void absentClientIdOverrideArgumentYieldsNoOverride() throws Exception {
+        assertThat(copierClientIdOverrideArg("8", "0", "cursor-x")).isNull();
     }
 
     @Test
@@ -126,6 +150,35 @@ class IndexMigrationToolTest {
                     .isInstanceOf(BufferedSenderUploader.class);
             assertThat(IndexMigrationTool.uploader(null, "e", "t", 250, new AtomicLong(), new AtomicLong()))
                     .isInstanceOf(BufferedSenderUploader.class); // default
+        }
+    }
+
+    /**
+     * Runs {@code main} with the five mandatory args followed by {@code extraArgs}, all Azure collaborators
+     * mocked, and returns the {@code clientIdOverride} (6th) argument the constructed {@link IndexCopier}
+     * received — asserting the tool's positional parsing threads it through correctly.
+     */
+    private static Object copierClientIdOverrideArg(final String... extraArgs) throws Exception {
+        final List<List<Object>> copierCtorArgs = new ArrayList<>();
+        final SearchIndexingBufferedSender<ChunkedEntry> sender = senderMock();
+
+        try (MockedStatic<SearchIndexAdmin> admin = mockStatic(SearchIndexAdmin.class);
+             MockedStatic<AISearchClientFactory> factory = mockStatic(AISearchClientFactory.class);
+             MockedConstruction<IndexCopier> copier = mockConstruction(IndexCopier.class, (m, ctx) -> {
+                 copierCtorArgs.add(new ArrayList<>(ctx.arguments()));
+                 when(m.copyAllDocuments(any())).thenReturn(1L);
+             })) {
+
+            admin.when(() -> SearchIndexAdmin.indexClient(any())).thenReturn(mock(SearchIndexClient.class));
+            admin.when(() -> SearchIndexAdmin.bufferedSender(any(), any(), anyInt(), any(), any())).thenReturn(sender);
+            factory.when(() -> AISearchClientFactory.getInstance(any(), any())).thenReturn(mock(SearchClient.class));
+
+            final String[] base = {ENDPOINT, "src-index", "tgt-index", "the-alias", "/schema.json"};
+            final String[] args = Arrays.copyOf(base, base.length + extraArgs.length);
+            System.arraycopy(extraArgs, 0, args, base.length, extraArgs.length);
+            IndexMigrationTool.main(args);
+
+            return copierCtorArgs.get(0).get(5); // the clientIdOverride constructor argument
         }
     }
 

--- a/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/table/TableCopierTest.java
+++ b/ai-document-migration-tool/src/test/java/uk/gov/moj/cp/migration/table/TableCopierTest.java
@@ -23,6 +23,7 @@ import com.azure.data.tables.models.TableErrorCode;
 import com.azure.data.tables.models.TableServiceError;
 import com.azure.data.tables.models.TableServiceException;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 /**
  * Unit tests for {@link TableCopier} with the source/target {@link TableClient}s mocked — no live service.
@@ -153,6 +154,26 @@ class TableCopierTest {
         verify(source, never()).upsertEntity(any());
         verify(source, never()).createEntity(any());
         verify(source, never()).deleteEntity(any());
+    }
+
+    @Test
+    void upsertsRowsUnderTheOverridePartitionKeyPreservingRowKeyAndDataColumns() {
+        // Closes the loop at the upsert boundary: with an override every copied row lands under the fixed
+        // partition key while its RowKey and data columns are preserved verbatim (no production change needed).
+        final TableClient source = sourceWith(entity("old-pk-1", "rk-1"), entity("old-pk-2", "rk-2"));
+        final TableClient target = mock(TableClient.class);
+
+        new TableCopier(source, target, OVERRIDE, 0).copyAllRows();
+
+        final ArgumentCaptor<TableEntity> upserted = ArgumentCaptor.forClass(TableEntity.class);
+        verify(target, times(2)).upsertEntity(upserted.capture());
+        assertThat(upserted.getAllValues())
+                .allSatisfy(row -> {
+                    assertThat(row.getPartitionKey()).isEqualTo(OVERRIDE);
+                    assertThat(row.getProperties()).containsEntry("DocumentStatus", "INGESTED");
+                })
+                .extracting(TableEntity::getRowKey)
+                .containsExactly("rk-1", "rk-2");
     }
 
     @Test


### PR DESCRIPTION
**Jira:** DD-42982 (sub-task of DD-42722)

Story MTDI07 (Phase 3 — migration tooling) of the multi-client data isolation initiative. Module: `ai-document-migration-tool` only; the tool is not deployed, so this is zero-risk to the running service.

## What's in this PR
- `IndexMigrationTool` accepts an optional positional `clientIdOverride` argument (blank or `-` = copy verbatim, matching the table tool's `partitionKeyOverride` convention) and logs the resolved override at startup so the operator sees exactly what will be stamped.
- `IndexCopier` stamps every copied chunk with the override — a builder copy that preserves all other fields (vector reference shared, so no bulk-run memory overhead); uploads remain idempotent upserts keyed by `id`, so re-runs are safe.
- `TableCopier` confirmed to need no change (targeted test added at the upsert boundary).
- Docs: README usage/args-table/worked example; SCHEMA_CHANGES gains the `clientId` field row and stamping note.

## Test evidence
- A-TDD: scaffolded red first (stamping + idempotent re-run), implementation made them green; 62/62 module tests pass, existing 54 unchanged.
- Structured code review: approve with minor comments — all addressed except one deliberate follow-up (a `ChunkedEntry.toBuilder()` hardening so future new fields can't be silently dropped by copy code; touches shared artefacts, tracked for a later story).

## Design & stories
`docs/pipeline/DD-42722-multi-tenant-data-isolation/` — [design](https://github.com/hmcts/cp-ai-rag-service/blob/main/docs/pipeline/DD-42722-multi-tenant-data-isolation/02-design.md) §F, [stories](https://github.com/hmcts/cp-ai-rag-service/blob/main/docs/pipeline/DD-42722-multi-tenant-data-isolation/03-stories.md) §MTDI07.