### PR TITLE
feat: client-aware idempotency and Table Storage re-keying for multi-client isolation

### DIFF
--- a/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/AnswerGenerationFunction.java
+++ b/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/AnswerGenerationFunction.java
@@ -169,7 +169,7 @@ public class AnswerGenerationFunction {
 
             LOGGER.info("Starting answer generation for transactionId '{}'", transactionId);
 
-            idempotencyGuard.runOnce(transactionId.toString(), token ->
+            idempotencyGuard.runOnce(null, transactionId.toString(), token ->
                     processWithClaim(validPayload, token, scoringMessage, dequeueCount, maxDequeueCount, startTime));
 
         } catch (RedeliveryException e) {
@@ -299,6 +299,7 @@ public class AnswerGenerationFunction {
     private void upsertTerminalFenced(final AnswerGenerationQueuePayload payload, final LlmResponse llmResponse,
                                       final String inputChunksFilename, final long durationMs, final ClaimToken token) {
         answerGenerationTableService.upsertTerminalFenced(
+                null,
                 payload.transactionId().toString(),
                 payload.userQuery(),
                 payload.queryPrompt(),
@@ -366,6 +367,7 @@ public class AnswerGenerationFunction {
     private void recordAnswerGenerationFailed(final AnswerGenerationQueuePayload payload, final String errorMessage,
                                               final long durationMs, final ClaimToken token) {
         answerGenerationTableService.upsertTerminalFenced(
+                null,
                 payload.transactionId().toString(),
                 payload.userQuery(),
                 payload.queryPrompt(),
@@ -389,7 +391,7 @@ public class AnswerGenerationFunction {
     private void recordAnswerGenerationFailedIfSafe(final AnswerGenerationQueuePayload payload, final String errorMessage, final long durationMs) {
         final String transactionId = payload.transactionId().toString();
         try {
-            final var snapshot = answerGenerationTableService.readForClaim(transactionId);
+            final var snapshot = answerGenerationTableService.readForClaim(null, transactionId);
             if (snapshot == null) {
                 answerGenerationTableService.upsertIntoTable(
                         transactionId, payload.userQuery(), payload.queryPrompt(),
@@ -405,7 +407,7 @@ public class AnswerGenerationFunction {
                 return;
             }
             answerGenerationTableService.upsertTerminalFenced(
-                    transactionId, payload.userQuery(), payload.queryPrompt(),
+                    null, transactionId, payload.userQuery(), payload.queryPrompt(),
                     null, null, ANSWER_GENERATION_FAILED, errorMessage, OffsetDateTime.now(), durationMs,
                     snapshot.etag());
         } catch (EtagMismatchException e) {

--- a/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/GetAnswerGenerationResultFunction.java
+++ b/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/GetAnswerGenerationResultFunction.java
@@ -85,7 +85,7 @@ public class GetAnswerGenerationResultFunction {
                 return generateResponse(request, BAD_REQUEST, errorMessage);
             }
 
-            final GeneratedAnswer generatedAnswer = answerGenerationTableService.getGeneratedAnswer(transactionId);
+            final GeneratedAnswer generatedAnswer = answerGenerationTableService.getGeneratedAnswer(null, transactionId);
 
             if (nonNull(generatedAnswer)) {
                 final boolean withChunkedEntries = parseBoolean(request.getQueryParameters().getOrDefault(PARAM_WITH_CHUNKED_ENTRIES, "false"));

--- a/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/InitiateAnswerGenerationFunction.java
+++ b/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/InitiateAnswerGenerationFunction.java
@@ -86,7 +86,7 @@ public class InitiateAnswerGenerationFunction {
             final AnswerGenerationQueuePayload answerGenerationQueuePayload = new AnswerGenerationQueuePayload(transactionId, userQuery, userQueryPrompt, metadataFilters);
             message.setValue(convert(answerGenerationQueuePayload));
 
-            answerGenerationTableService.saveAnswerGenerationRequest(transactionId.toString(), userQuery, userQueryPrompt, ANSWER_GENERATION_PENDING);
+            answerGenerationTableService.saveAnswerGenerationRequest(null, transactionId.toString(), userQuery, userQueryPrompt, ANSWER_GENERATION_PENDING);
             LOGGER.info("Successfully initiated answer retrieval processing for the query: {} with transactionId: {}", userQuery, transactionId);
 
             return generateResponse(request, ACCEPTED, convert(new UserQueryAnswerRequestAccepted(transactionId.toString())));

--- a/ai-document-answer-retrieval-function/src/test/java/uk/gov/moj/cp/retrieval/AnswerGenerationFunctionTest.java
+++ b/ai-document-answer-retrieval-function/src/test/java/uk/gov/moj/cp/retrieval/AnswerGenerationFunctionTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNotNull;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -100,10 +101,10 @@ class AnswerGenerationFunctionTest {
 
     /** The status row is claimable: PENDING, no live lease; the claim returns CLAIM_ETAG. */
     private void stubClaimableRow(final UUID transactionId) throws Exception {
-        when(mockAnswerGenerationTableService.readForClaim(transactionId.toString()))
+        when(mockAnswerGenerationTableService.readForClaim(null, transactionId.toString()))
                 .thenReturn(new LeaseSnapshot("ANSWER_GENERATION_PENDING", READ_ETAG, null, null));
         when(mockAnswerGenerationTableService.claimLease(
-                eq(transactionId.toString()), eq(READ_ETAG), anyString(), any(OffsetDateTime.class)))
+                isNull(), eq(transactionId.toString()), eq(READ_ETAG), anyString(), any(OffsetDateTime.class)))
                 .thenReturn(CLAIM_ETAG);
     }
 
@@ -117,7 +118,7 @@ class AnswerGenerationFunctionTest {
         verify(mockEmbedDataService, never()).getEmbedding(anyString());
         verify(mockScoringOutputBinding, never()).setValue(anyString());
         verify(mockAnswerGenerationTableService, never()).upsertTerminalFenced(
-                anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+                any(), anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any()
         );
     }
 
@@ -138,7 +139,7 @@ class AnswerGenerationFunctionTest {
         verify(mockEmbedDataService, never()).getEmbedding(anyString());
         verify(mockScoringOutputBinding, never()).setValue(anyString());
         verify(mockAnswerGenerationTableService, never()).upsertTerminalFenced(
-                anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+                any(), anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any()
         );
     }
 
@@ -181,6 +182,7 @@ class AnswerGenerationFunctionTest {
         function.run(queueMessage, mockScoringOutputBinding, 1, context);
 
         verify(mockAnswerGenerationTableService).upsertTerminalFenced(
+                isNull(),
                 eq(transactionId.toString()),
                 eq("query"),
                 eq("prompt"),
@@ -214,7 +216,7 @@ class AnswerGenerationFunctionTest {
         );
 
         // completed successfully — the lease must not be released
-        verify(mockAnswerGenerationTableService, never()).releaseLease(anyString(), anyString());
+        verify(mockAnswerGenerationTableService, never()).releaseLease(any(), anyString(), anyString());
     }
 
     @Test
@@ -256,6 +258,7 @@ class AnswerGenerationFunctionTest {
         function.run(queueMessage, mockScoringOutputBinding, 1, context);
 
         verify(mockAnswerGenerationTableService).upsertTerminalFenced(
+                isNull(),
                 eq(transactionId.toString()),
                 eq("query"),
                 eq("prompt"),
@@ -283,7 +286,7 @@ class AnswerGenerationFunctionTest {
                 transactionId, "query", "prompt", List.of(new KeyValuePair("key", "value")));
         final String queueMessage = objectMapper.writeValueAsString(payload);
 
-        when(mockAnswerGenerationTableService.readForClaim(transactionId.toString()))
+        when(mockAnswerGenerationTableService.readForClaim(null, transactionId.toString()))
                 .thenReturn(new LeaseSnapshot("ANSWER_GENERATED", READ_ETAG, null, null));
         when(mockAnswerGenerationTableService.isTerminal("ANSWER_GENERATED")).thenReturn(true);
 
@@ -292,9 +295,9 @@ class AnswerGenerationFunctionTest {
         // no expensive work, no writes, no scoring re-enqueue
         verify(mockEmbedDataService, never()).getEmbedding(anyString());
         verify(mockScoringOutputBinding, never()).setValue(anyString());
-        verify(mockAnswerGenerationTableService, never()).claimLease(anyString(), anyString(), anyString(), any());
+        verify(mockAnswerGenerationTableService, never()).claimLease(any(), anyString(), anyString(), anyString(), any());
         verify(mockAnswerGenerationTableService, never()).upsertTerminalFenced(
-                anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+                any(), anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -304,7 +307,7 @@ class AnswerGenerationFunctionTest {
                 transactionId, "query", "prompt", List.of(new KeyValuePair("key", "value")));
         final String queueMessage = objectMapper.writeValueAsString(payload);
 
-        when(mockAnswerGenerationTableService.readForClaim(transactionId.toString()))
+        when(mockAnswerGenerationTableService.readForClaim(null, transactionId.toString()))
                 .thenReturn(new LeaseSnapshot("ANSWER_GENERATION_PENDING", READ_ETAG,
                         OffsetDateTime.now().plusMinutes(5), "other-worker"));
 
@@ -313,7 +316,7 @@ class AnswerGenerationFunctionTest {
 
         assertThat(ex.getMessage(), is(format("Retrying AnswerGeneration for transactionId='%s' (lease held)", transactionId)));
         verify(mockEmbedDataService, never()).getEmbedding(anyString());
-        verify(mockAnswerGenerationTableService, never()).claimLease(anyString(), anyString(), anyString(), any());
+        verify(mockAnswerGenerationTableService, never()).claimLease(any(), anyString(), anyString(), anyString(), any());
     }
 
     @Test
@@ -323,7 +326,7 @@ class AnswerGenerationFunctionTest {
                 transactionId, "query", "prompt", List.of(new KeyValuePair("key", "value")));
         final String queueMessage = objectMapper.writeValueAsString(payload);
 
-        when(mockAnswerGenerationTableService.readForClaim(transactionId.toString()))
+        when(mockAnswerGenerationTableService.readForClaim(null, transactionId.toString()))
                 .thenReturn(new LeaseSnapshot("ANSWER_GENERATION_PENDING", READ_ETAG,
                         OffsetDateTime.now().plusMinutes(5), "other-worker"));
 
@@ -331,7 +334,7 @@ class AnswerGenerationFunctionTest {
 
         // never overwrite a possibly-completing leaseholder with FAILED
         verify(mockAnswerGenerationTableService, never()).upsertTerminalFenced(
-                anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+                any(), anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any());
         verify(mockAnswerGenerationTableService, never()).upsertIntoTable(
                 anyString(), any(), any(), any(), any(), any(), any(), any(), any());
         verify(mockScoringOutputBinding, never()).setValue(anyString());
@@ -349,11 +352,11 @@ class AnswerGenerationFunctionTest {
                 .id("1").chunk("Sample content").documentFileName("doc.pdf").pageNumber(1).documentId("doc1")
                 .build());
 
-        when(mockAnswerGenerationTableService.readForClaim(transactionId.toString()))
+        when(mockAnswerGenerationTableService.readForClaim(null, transactionId.toString()))
                 .thenReturn(new LeaseSnapshot("ANSWER_GENERATION_PENDING", READ_ETAG,
                         OffsetDateTime.now().minusMinutes(5), "crashed-worker"));
         when(mockAnswerGenerationTableService.claimLease(
-                eq(transactionId.toString()), eq(READ_ETAG), anyString(), any(OffsetDateTime.class)))
+                isNull(), eq(transactionId.toString()), eq(READ_ETAG), anyString(), any(OffsetDateTime.class)))
                 .thenReturn(CLAIM_ETAG);
 
         when(mockEmbedDataService.getEmbedding("query")).thenReturn(embeddings);
@@ -364,6 +367,7 @@ class AnswerGenerationFunctionTest {
         function.run(queueMessage, mockScoringOutputBinding, 2, context);
 
         verify(mockAnswerGenerationTableService).upsertTerminalFenced(
+                isNull(),
                 eq(transactionId.toString()), eq("query"), eq("prompt"), any(), eq("generated response"),
                 eq(ANSWER_GENERATED), eq(null), any(OffsetDateTime.class), any(Long.class), eq(CLAIM_ETAG));
         verify(mockScoringOutputBinding).setValue(anyString());
@@ -389,7 +393,7 @@ class AnswerGenerationFunctionTest {
 
         doThrow(new EtagMismatchException("etag changed"))
                 .when(mockAnswerGenerationTableService).upsertTerminalFenced(
-                        anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+                        any(), anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any());
 
         // completes silently: no rethrow, result discarded
         assertDoesNotThrow(() -> function.run(queueMessage, mockScoringOutputBinding, 1, context));
@@ -400,7 +404,7 @@ class AnswerGenerationFunctionTest {
         verify(mockAnswerGenerationTableService, never()).upsertIntoTable(
                 anyString(), any(), any(), any(), any(), any(), any(), any(), any());
         // and the guard skips the (pointless) release of an already-stale lease
-        verify(mockAnswerGenerationTableService, never()).releaseLease(anyString(), anyString());
+        verify(mockAnswerGenerationTableService, never()).releaseLease(any(), anyString(), anyString());
     }
 
     // ---- citation guard: retry via queue redelivery, policy at exhaustion ----
@@ -431,11 +435,11 @@ class AnswerGenerationFunctionTest {
                 () -> function.run(queueMessage, mockScoringOutputBinding, 1, context));
 
         assertThat(ex.getMessage(), is(format("Retrying AnswerGeneration for transactionId='%s' (citation-degraded)", transactionId)));
-        verify(mockAnswerGenerationTableService, never()).upsertTerminalFenced(anyString(), anyString(), anyString(),
+        verify(mockAnswerGenerationTableService, never()).upsertTerminalFenced(any(), anyString(), anyString(), anyString(),
                 any(), any(), any(), any(), any(OffsetDateTime.class), any(Long.class), any());
         verify(mockScoringOutputBinding, never()).setValue(anyString());
         // the lease is released before the rethrow so the intentional retry re-claims immediately
-        verify(mockAnswerGenerationTableService).releaseLease(transactionId.toString(), CLAIM_ETAG);
+        verify(mockAnswerGenerationTableService).releaseLease(null, transactionId.toString(), CLAIM_ETAG);
     }
 
     @Test
@@ -447,6 +451,7 @@ class AnswerGenerationFunctionTest {
         function.run(queueMessage, mockScoringOutputBinding, 3, context);
 
         verify(mockAnswerGenerationTableService).upsertTerminalFenced(
+                isNull(),
                 eq(transactionId.toString()),
                 eq("query"),
                 eq("prompt"),
@@ -475,6 +480,7 @@ class AnswerGenerationFunctionTest {
         function.run(queueMessage, mockScoringOutputBinding, 3, context);
 
         verify(mockAnswerGenerationTableService).upsertTerminalFenced(
+                isNull(),
                 eq(transactionId.toString()),
                 eq("query"),
                 eq("prompt"),
@@ -511,6 +517,7 @@ class AnswerGenerationFunctionTest {
         function.run(queueMessage, mockScoringOutputBinding, 3, context);
 
         verify(mockAnswerGenerationTableService).upsertTerminalFenced(
+                isNull(),
                 eq(transactionId.toString()),
                 eq("query"),
                 eq("prompt"),
@@ -549,7 +556,7 @@ class AnswerGenerationFunctionTest {
 
         assertThat(exception.getMessage(), is("Retrying AnswerGeneration for transactionId='" + transactionId + "'"));
         // the lease is released before the rethrow so the redelivery can re-claim immediately
-        verify(mockAnswerGenerationTableService).releaseLease(transactionId.toString(), CLAIM_ETAG);
+        verify(mockAnswerGenerationTableService).releaseLease(null, transactionId.toString(), CLAIM_ETAG);
     }
 
     @Test
@@ -559,10 +566,10 @@ class AnswerGenerationFunctionTest {
                 transactionId, "query", "prompt", List.of(new KeyValuePair("key", "value")));
         final String queueMessage = objectMapper.writeValueAsString(payload);
 
-        when(mockAnswerGenerationTableService.readForClaim(transactionId.toString()))
+        when(mockAnswerGenerationTableService.readForClaim(null, transactionId.toString()))
                 .thenReturn(new LeaseSnapshot("ANSWER_GENERATION_PENDING", READ_ETAG, null, null));
         when(mockAnswerGenerationTableService.claimLease(
-                eq(transactionId.toString()), eq(READ_ETAG), anyString(), any(OffsetDateTime.class)))
+                isNull(), eq(transactionId.toString()), eq(READ_ETAG), anyString(), any(OffsetDateTime.class)))
                 .thenThrow(new EtagMismatchException("etag changed"));
 
         final RuntimeException ex = assertThrows(RuntimeException.class,

--- a/ai-document-answer-retrieval-function/src/test/java/uk/gov/moj/cp/retrieval/GetAnswerGenerationResultFunctionTest.java
+++ b/ai-document-answer-retrieval-function/src/test/java/uk/gov/moj/cp/retrieval/GetAnswerGenerationResultFunctionTest.java
@@ -105,7 +105,7 @@ class GetAnswerGenerationResultFunctionTest {
                 "LLM response", ANSWER_GENERATED.name(), null, OffsetDateTime.now(), 123L);
 
         when(request.getQueryParameters()).thenReturn(Map.of(PARAM_WITH_CHUNKED_ENTRIES, "true"));
-        when(tableStorageService.getGeneratedAnswer(transactionId)).thenReturn(generatedAnswer);
+        when(tableStorageService.getGeneratedAnswer(null, transactionId)).thenReturn(generatedAnswer);
         when(blobPersistenceInputChunksService.readBlob(eq(getInputChunksFilename(fromString(transactionId))), any())).thenReturn(new InputChunksPayload(List.of(builder()
                 .id(randomUUID().toString()).chunk("").documentFileName("doc2").pageNumber(2).documentId(randomUUID().toString()).build())));
 
@@ -137,7 +137,7 @@ class GetAnswerGenerationResultFunctionTest {
         when(generatedAnswer.getResponseGenerationDuration()).thenReturn(123L);
         when(request.getQueryParameters()).thenReturn(Map.of(PARAM_WITH_CHUNKED_ENTRIES, "false"));
 
-        when(tableStorageService.getGeneratedAnswer(transactionId)).thenReturn(generatedAnswer);
+        when(tableStorageService.getGeneratedAnswer(null, transactionId)).thenReturn(generatedAnswer);
 
         function.run(request, transactionId, context);
 
@@ -157,7 +157,7 @@ class GetAnswerGenerationResultFunctionTest {
         when(generatedAnswer.getTransactionId()).thenReturn(transactionId);
         when(generatedAnswer.getAnswerStatus()).thenReturn(ANSWER_GENERATION_PENDING.name());
 
-        when(tableStorageService.getGeneratedAnswer(transactionId)).thenReturn(generatedAnswer);
+        when(tableStorageService.getGeneratedAnswer(null, transactionId)).thenReturn(generatedAnswer);
 
         function.run(request, transactionId, context);
 
@@ -174,7 +174,7 @@ class GetAnswerGenerationResultFunctionTest {
     void shouldReturnNotFoundWhenNoAnswerExists() throws EntityRetrievalException {
         final String transactionId = randomUUID().toString();
 
-        when(tableStorageService.getGeneratedAnswer(transactionId)).thenReturn(null);
+        when(tableStorageService.getGeneratedAnswer(null, transactionId)).thenReturn(null);
 
         function.run(request, transactionId, context);
 
@@ -185,7 +185,7 @@ class GetAnswerGenerationResultFunctionTest {
     void shouldReturnInternalServerErrorOnException() throws EntityRetrievalException {
         final String transactionId = randomUUID().toString();
 
-        when(tableStorageService.getGeneratedAnswer(transactionId)).thenThrow(new RuntimeException("DB failure"));
+        when(tableStorageService.getGeneratedAnswer(null, transactionId)).thenThrow(new RuntimeException("DB failure"));
 
         function.run(request, transactionId, context);
 

--- a/ai-document-answer-retrieval-function/src/test/java/uk/gov/moj/cp/retrieval/InitiateAnswerGenerationFunctionTest.java
+++ b/ai-document-answer-retrieval-function/src/test/java/uk/gov/moj/cp/retrieval/InitiateAnswerGenerationFunctionTest.java
@@ -6,6 +6,7 @@ import static com.microsoft.azure.functions.HttpStatus.ACCEPTED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -81,7 +82,7 @@ class InitiateAnswerGenerationFunctionTest {
 
         assertEquals(ACCEPTED, result.getStatus());
         verify(outputBinding).setValue(anyString());
-        verify(answerGenerationTableService).saveAnswerGenerationRequest(anyString(),
+        verify(answerGenerationTableService).saveAnswerGenerationRequest(isNull(), anyString(),
                 eq(userQuery), eq(queryPrompt),
                 eq(ANSWER_GENERATION_PENDING));
 

--- a/ai-document-answer-scoring-function/src/main/java/uk/gov/moj/cp/scoring/AnswerScoringFunction.java
+++ b/ai-document-answer-scoring-function/src/main/java/uk/gov/moj/cp/scoring/AnswerScoringFunction.java
@@ -80,7 +80,7 @@ public class AnswerScoringFunction {
 
             if(null != scoringPayload.transactionId()) {
                 LOGGER.info("Recording groundedness score against transaction id: {}", scoringPayload.transactionId());
-                answerGenerationTableService.recordGroundednessScore(scoringPayload.transactionId(), modelScore.groundednessScore());
+                answerGenerationTableService.recordGroundednessScore(null, scoringPayload.transactionId(), modelScore.groundednessScore());
             }
 
             LOGGER.info("Answer scoring processing completed successfully for message with score : {}", modelScore.groundednessScore());

--- a/ai-document-answer-scoring-function/src/test/java/uk/gov/moj/cp/scoring/AnswerScoringFunctionTest.java
+++ b/ai-document-answer-scoring-function/src/test/java/uk/gov/moj/cp/scoring/AnswerScoringFunctionTest.java
@@ -61,7 +61,7 @@ class AnswerScoringFunctionTest {
 
         verify(scoringServiceMock).evaluateGroundedness(scoringPayload.llmResponse(), scoringPayload.userQuery(), scoringPayload.queryPrompt(), List.of());
         verify(publishScoreService).publishGroundednessScore(llmScore, scoringPayload.userQuery());
-        verify(answerGenerationTableService).recordGroundednessScore(scoringPayload.transactionId(), llmScore);
+        verify(answerGenerationTableService).recordGroundednessScore(null, scoringPayload.transactionId(), llmScore);
     }
 
     @Test

--- a/ai-document-ingestion-function/src/main/java/uk/gov/moj/cp/ingestion/DocumentIngestionFunction.java
+++ b/ai-document-ingestion-function/src/main/java/uk/gov/moj/cp/ingestion/DocumentIngestionFunction.java
@@ -86,7 +86,7 @@ public class DocumentIngestionFunction {
                     queueIngestionMetadata.documentName(),
                     queueIngestionMetadata.blobUrl());
 
-            idempotencyGuard.runOnce(documentId, token ->
+            idempotencyGuard.runOnce(null, documentId, token ->
                     processUnderClaim(queueIngestionMetadata, token, dequeueCount, maxDequeueCount));
 
         } catch (EtagMismatchException e) {

--- a/ai-document-ingestion-function/src/main/java/uk/gov/moj/cp/ingestion/service/DocumentIngestionOrchestrator.java
+++ b/ai-document-ingestion-function/src/main/java/uk/gov/moj/cp/ingestion/service/DocumentIngestionOrchestrator.java
@@ -144,7 +144,7 @@ public class DocumentIngestionOrchestrator {
     public void processQueueMessageFailedIfSafe(final QueueIngestionMetadata queueIngestionMetadata) {
         final String documentId = queueIngestionMetadata.documentId();
         try {
-            final LeaseSnapshot snapshot = documentIngestionOutcomeTableService.readForClaim(documentId);
+            final LeaseSnapshot snapshot = documentIngestionOutcomeTableService.readForClaim(null, documentId);
             if (snapshot == null) {
                 LOGGER.error("Not recording INGESTION_FAILED for documentId: {} — status row is missing.", documentId);
                 return;
@@ -158,7 +158,7 @@ public class DocumentIngestionOrchestrator {
                 return;
             }
             documentIngestionOutcomeTableService.recordOutcomeFenced(
-                    documentId, INGESTION_FAILED.name(), INGESTION_FAILED_REASON, snapshot.etag());
+                    null, documentId, INGESTION_FAILED.name(), INGESTION_FAILED_REASON, snapshot.etag());
 
         } catch (EtagMismatchException e) {
             LOGGER.warn("Not recording INGESTION_FAILED for documentId: {} — row changed concurrently; leaving the outcome to its owner.", documentId, e);
@@ -169,7 +169,7 @@ public class DocumentIngestionOrchestrator {
 
     private void markSupersededDocumentsInactive(final String documentId) throws DocumentProcessingException {
         try {
-            final DocumentIngestionOutcome document = documentIngestionOutcomeTableService.getDocumentById(documentId);
+            final DocumentIngestionOutcome document = documentIngestionOutcomeTableService.getDocumentById(null, documentId);
             if (nonNull(document) && !isNullOrEmpty(document.getSupersededDocuments())) {
                 final List<String> supersededDocs = Arrays.stream(document.getSupersededDocuments().split(","))
                         .map(String::trim)
@@ -186,7 +186,7 @@ public class DocumentIngestionOrchestrator {
     private void recordOutcome(final String documentName, final String documentId,
                                final String status, final String reason, final ClaimToken token) throws DocumentProcessingException {
         try {
-            documentIngestionOutcomeTableService.recordOutcomeFenced(documentId, status, reason, token.etag());
+            documentIngestionOutcomeTableService.recordOutcomeFenced(null, documentId, status, reason, token.etag());
             LOGGER.info("event=outcome_recorded status={} documentName={} documentId={}", status, documentName, documentId);
         } catch (EtagMismatchException fenceLoss) {
             // Never convert a fence loss into a retry or a FAILED write — the reclaimer owns the outcome.

--- a/ai-document-ingestion-function/src/test/java/uk/gov/moj/cp/ingestion/DocumentIngestionFunctionTest.java
+++ b/ai-document-ingestion-function/src/test/java/uk/gov/moj/cp/ingestion/DocumentIngestionFunctionTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -78,10 +79,10 @@ class DocumentIngestionFunctionTest {
 
     /** Row is claimable: non-terminal status, no live lease; the claim returns CLAIM_ETAG. */
     private void stubClaimableRow() throws Exception {
-        when(outcomeTableService.readForClaim(DOCUMENT_ID))
+        when(outcomeTableService.readForClaim(null, DOCUMENT_ID))
                 .thenReturn(new LeaseSnapshot("AWAITING_INGESTION", READ_ETAG, null, null));
         when(outcomeTableService.isTerminal("AWAITING_INGESTION")).thenReturn(false);
-        when(outcomeTableService.claimLease(eq(DOCUMENT_ID), eq(READ_ETAG), anyString(), any(OffsetDateTime.class)))
+        when(outcomeTableService.claimLease(isNull(), eq(DOCUMENT_ID), eq(READ_ETAG), anyString(), any(OffsetDateTime.class)))
                 .thenReturn(CLAIM_ETAG);
     }
 
@@ -96,7 +97,7 @@ class DocumentIngestionFunctionTest {
         documentIngestionFunction.run(queueMessage(metadata), 1);
 
         // then
-        verify(documentIngestionOrchestrator).processQueueMessage(metadata, new ClaimToken(DOCUMENT_ID, CLAIM_ETAG));
+        verify(documentIngestionOrchestrator).processQueueMessage(metadata, new ClaimToken(null, DOCUMENT_ID, CLAIM_ETAG));
     }
 
     @Test
@@ -118,7 +119,7 @@ class DocumentIngestionFunctionTest {
     @DisplayName("Skip processing entirely when the status row is already terminal")
     void shouldSkipWhenRowIsTerminal() throws Exception {
         // given
-        when(outcomeTableService.readForClaim(DOCUMENT_ID))
+        when(outcomeTableService.readForClaim(null, DOCUMENT_ID))
                 .thenReturn(new LeaseSnapshot("INGESTION_SUCCESS", READ_ETAG, null, null));
         when(outcomeTableService.isTerminal("INGESTION_SUCCESS")).thenReturn(true);
 
@@ -127,14 +128,14 @@ class DocumentIngestionFunctionTest {
 
         // then
         verifyNoInteractions(documentIngestionOrchestrator);
-        verify(outcomeTableService, never()).claimLease(anyString(), anyString(), anyString(), any());
+        verify(outcomeTableService, never()).claimLease(any(), anyString(), anyString(), anyString(), any());
     }
 
     @Test
     @DisplayName("Rethrow to redeliver when another worker holds a live lease and budget remains")
     void shouldRethrowWhenLiveLeaseHeldAndBudgetRemains() throws Exception {
         // given
-        when(outcomeTableService.readForClaim(DOCUMENT_ID))
+        when(outcomeTableService.readForClaim(null, DOCUMENT_ID))
                 .thenReturn(new LeaseSnapshot("AWAITING_INGESTION", READ_ETAG, OffsetDateTime.now().plusMinutes(5), "other-worker"));
         when(outcomeTableService.isTerminal("AWAITING_INGESTION")).thenReturn(false);
 
@@ -143,14 +144,14 @@ class DocumentIngestionFunctionTest {
                 () -> documentIngestionFunction.run(queueMessage(metadata()), 1));
         assertTrue(exception.getMessage().contains("Lease held by another worker"));
         verifyNoInteractions(documentIngestionOrchestrator);
-        verify(outcomeTableService, never()).claimLease(anyString(), anyString(), anyString(), any());
+        verify(outcomeTableService, never()).claimLease(any(), anyString(), anyString(), anyString(), any());
     }
 
     @Test
     @DisplayName("Do NOT write FAILED when attempts exhaust against a live lease — leave the outcome to the leaseholder")
     void shouldNotWriteFailedWhenExhaustedAgainstLiveLease() throws Exception {
         // given
-        when(outcomeTableService.readForClaim(DOCUMENT_ID))
+        when(outcomeTableService.readForClaim(null, DOCUMENT_ID))
                 .thenReturn(new LeaseSnapshot("AWAITING_INGESTION", READ_ETAG, OffsetDateTime.now().plusMinutes(5), "other-worker"));
         when(outcomeTableService.isTerminal("AWAITING_INGESTION")).thenReturn(false);
 
@@ -166,27 +167,27 @@ class DocumentIngestionFunctionTest {
     void shouldReclaimExpiredLease() throws Exception {
         // given
         final QueueIngestionMetadata metadata = metadata();
-        when(outcomeTableService.readForClaim(DOCUMENT_ID))
+        when(outcomeTableService.readForClaim(null, DOCUMENT_ID))
                 .thenReturn(new LeaseSnapshot("AWAITING_INGESTION", READ_ETAG, OffsetDateTime.now().minusMinutes(5), "crashed-worker"));
         when(outcomeTableService.isTerminal("AWAITING_INGESTION")).thenReturn(false);
-        when(outcomeTableService.claimLease(eq(DOCUMENT_ID), eq(READ_ETAG), anyString(), any(OffsetDateTime.class)))
+        when(outcomeTableService.claimLease(isNull(), eq(DOCUMENT_ID), eq(READ_ETAG), anyString(), any(OffsetDateTime.class)))
                 .thenReturn(CLAIM_ETAG);
 
         // when
         documentIngestionFunction.run(queueMessage(metadata), 1);
 
         // then
-        verify(documentIngestionOrchestrator).processQueueMessage(metadata, new ClaimToken(DOCUMENT_ID, CLAIM_ETAG));
+        verify(documentIngestionOrchestrator).processQueueMessage(metadata, new ClaimToken(null, DOCUMENT_ID, CLAIM_ETAG));
     }
 
     @Test
     @DisplayName("Rethrow to redeliver when the claim race is lost")
     void shouldRethrowWhenClaimRaceLost() throws Exception {
         // given
-        when(outcomeTableService.readForClaim(DOCUMENT_ID))
+        when(outcomeTableService.readForClaim(null, DOCUMENT_ID))
                 .thenReturn(new LeaseSnapshot("AWAITING_INGESTION", READ_ETAG, null, null));
         when(outcomeTableService.isTerminal("AWAITING_INGESTION")).thenReturn(false);
-        when(outcomeTableService.claimLease(eq(DOCUMENT_ID), eq(READ_ETAG), anyString(), any(OffsetDateTime.class)))
+        when(outcomeTableService.claimLease(isNull(), eq(DOCUMENT_ID), eq(READ_ETAG), anyString(), any(OffsetDateTime.class)))
                 .thenThrow(new EtagMismatchException("etag changed"));
 
         // when & then
@@ -200,15 +201,15 @@ class DocumentIngestionFunctionTest {
     void shouldCreateClaimedRowWhenRowMissing() throws Exception {
         // given
         final QueueIngestionMetadata metadata = metadata();
-        when(outcomeTableService.readForClaim(DOCUMENT_ID)).thenReturn(null);
-        when(outcomeTableService.createClaimedRow(eq(DOCUMENT_ID), anyString(), any(OffsetDateTime.class)))
+        when(outcomeTableService.readForClaim(null, DOCUMENT_ID)).thenReturn(null);
+        when(outcomeTableService.createClaimedRow(isNull(), eq(DOCUMENT_ID), anyString(), any(OffsetDateTime.class)))
                 .thenReturn(CLAIM_ETAG);
 
         // when
         documentIngestionFunction.run(queueMessage(metadata), 1);
 
         // then
-        verify(documentIngestionOrchestrator).processQueueMessage(metadata, new ClaimToken(DOCUMENT_ID, CLAIM_ETAG));
+        verify(documentIngestionOrchestrator).processQueueMessage(metadata, new ClaimToken(null, DOCUMENT_ID, CLAIM_ETAG));
     }
 
     @Test
@@ -226,7 +227,7 @@ class DocumentIngestionFunctionTest {
         verify(documentIngestionOrchestrator, never()).processQueueMessageFailed(any(), any());
         verify(documentIngestionOrchestrator, never()).processQueueMessageFailedIfSafe(any());
         // the guard skips releasing an already-stale lease (a release would be a guaranteed 412)
-        verify(outcomeTableService, never()).releaseLease(anyString(), anyString());
+        verify(outcomeTableService, never()).releaseLease(any(), anyString(), anyString());
     }
 
     @Test
@@ -241,7 +242,7 @@ class DocumentIngestionFunctionTest {
         final DocumentProcessingException exception = assertThrows(DocumentProcessingException.class,
                 () -> documentIngestionFunction.run(queueMessage(metadata()), 1));
         assertEquals("Error processing queueMessage", exception.getMessage());
-        verify(outcomeTableService).releaseLease(DOCUMENT_ID, CLAIM_ETAG);
+        verify(outcomeTableService).releaseLease(null, DOCUMENT_ID, CLAIM_ETAG);
     }
 
     @Test
@@ -257,7 +258,7 @@ class DocumentIngestionFunctionTest {
         documentIngestionFunction.run(queueMessage(metadata), 3);
 
         // then
-        verify(documentIngestionOrchestrator).processQueueMessageFailed(metadata, new ClaimToken(DOCUMENT_ID, CLAIM_ETAG));
+        verify(documentIngestionOrchestrator).processQueueMessageFailed(metadata, new ClaimToken(null, DOCUMENT_ID, CLAIM_ETAG));
     }
 
     @Test

--- a/ai-document-ingestion-function/src/test/java/uk/gov/moj/cp/ingestion/service/DocumentIngestionOrchestratorTest.java
+++ b/ai-document-ingestion-function/src/test/java/uk/gov/moj/cp/ingestion/service/DocumentIngestionOrchestratorTest.java
@@ -37,7 +37,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DocumentIngestionOrchestratorTest {
 
-    private static final ClaimToken TOKEN = new ClaimToken("claim-key", "W/\"datetime'2026-01-01T00%3A00%3A00Z'\"");
+    private static final ClaimToken TOKEN = new ClaimToken(null, "claim-key", "W/\"datetime'2026-01-01T00%3A00%3A00Z'\"");
 
     @Mock
     private DocumentIngestionOutcomeTableService documentIngestionOutcomeTableService;
@@ -70,13 +70,13 @@ class DocumentIngestionOrchestratorTest {
                 "2025-10-07T10:30:45.123456Z"
         );
 
-        doNothing().when(documentIngestionOutcomeTableService).recordOutcomeFenced(anyString(), anyString(), anyString(), anyString());
+        doNothing().when(documentIngestionOutcomeTableService).recordOutcomeFenced(any(), anyString(), anyString(), anyString(), anyString());
 
         // when
         orchestrator.processQueueMessage(metadata, TOKEN);
 
         // then
-        verify(documentIngestionOutcomeTableService).recordOutcomeFenced("123e4567-e89b-12d3-a456-426614174000", "INGESTION_SUCCESS", "Document ingestion completed successfully", TOKEN.etag());
+        verify(documentIngestionOutcomeTableService).recordOutcomeFenced(null, "123e4567-e89b-12d3-a456-426614174000", "INGESTION_SUCCESS", "Document ingestion completed successfully", TOKEN.etag());
     }
 
     @Test
@@ -91,13 +91,13 @@ class DocumentIngestionOrchestratorTest {
                 "2025-10-06T05:14:39.658828Z"
         );
 
-        doNothing().when(documentIngestionOutcomeTableService).recordOutcomeFenced(anyString(), anyString(), anyString(), anyString());
+        doNothing().when(documentIngestionOutcomeTableService).recordOutcomeFenced(any(), anyString(), anyString(), anyString(), anyString());
 
         // when
         orchestrator.processQueueMessage(metadata, TOKEN);
 
         // then
-        verify(documentIngestionOutcomeTableService).recordOutcomeFenced("53ac8b90-c4c8-472c-a5ee-fe84ed96047b", "INGESTION_SUCCESS", "Document ingestion completed successfully", TOKEN.etag());
+        verify(documentIngestionOutcomeTableService).recordOutcomeFenced(null, "53ac8b90-c4c8-472c-a5ee-fe84ed96047b", "INGESTION_SUCCESS", "Document ingestion completed successfully", TOKEN.etag());
     }
 
     @Test
@@ -112,13 +112,13 @@ class DocumentIngestionOrchestratorTest {
                 "2025-10-07T12:00:00.000000Z"
         );
 
-        doNothing().when(documentIngestionOutcomeTableService).recordOutcomeFenced(anyString(), anyString(), anyString(), anyString());
+        doNothing().when(documentIngestionOutcomeTableService).recordOutcomeFenced(any(), anyString(), anyString(), anyString(), anyString());
 
         // when
         orchestrator.processQueueMessage(metadata, TOKEN);
 
         // then
-        verify(documentIngestionOutcomeTableService).recordOutcomeFenced("456e7890-f123-4567-8901-234567890123", "INGESTION_SUCCESS", "Document ingestion completed successfully", TOKEN.etag());
+        verify(documentIngestionOutcomeTableService).recordOutcomeFenced(null, "456e7890-f123-4567-8901-234567890123", "INGESTION_SUCCESS", "Document ingestion completed successfully", TOKEN.etag());
     }
 
     @Test
@@ -133,13 +133,14 @@ class DocumentIngestionOrchestratorTest {
                 "2025-10-07T15:45:30.987654Z"
         );
 
-        doNothing().when(documentIngestionOutcomeTableService).recordOutcomeFenced(anyString(), anyString(), anyString(), anyString());
+        doNothing().when(documentIngestionOutcomeTableService).recordOutcomeFenced(any(), anyString(), anyString(), anyString(), anyString());
 
         // when
         orchestrator.processQueueMessage(metadata, TOKEN);
 
         // then
         verify(documentIngestionOutcomeTableService).recordOutcomeFenced(
+                null,
                 "789e0123-f456-7890-abcd-ef1234567890",
                 "INGESTION_SUCCESS",
                 "Document ingestion completed successfully",
@@ -161,8 +162,8 @@ class DocumentIngestionOrchestratorTest {
 
         final DocumentIngestionOutcome documentIngestionOutcome = mock(DocumentIngestionOutcome.class);
         when(documentIngestionOutcome.getSupersededDocuments()).thenReturn("67d6aeac-c533-41aa-9824-cc4ef7a346ef,569fefd2-d032-4c01-be59-b9045de5f43a");
-        when(documentIngestionOutcomeTableService.getDocumentById(documentId)).thenReturn(documentIngestionOutcome);
-        doNothing().when(documentIngestionOutcomeTableService).recordOutcomeFenced("789e0123-f456-7890-abcd-ef1234567890", "INGESTION_SUCCESS", "Document ingestion completed successfully", TOKEN.etag());
+        when(documentIngestionOutcomeTableService.getDocumentById(null, documentId)).thenReturn(documentIngestionOutcome);
+        doNothing().when(documentIngestionOutcomeTableService).recordOutcomeFenced(null, "789e0123-f456-7890-abcd-ef1234567890", "INGESTION_SUCCESS", "Document ingestion completed successfully", TOKEN.etag());
 
         // when
         orchestrator.processQueueMessage(metadata, TOKEN);
@@ -170,6 +171,7 @@ class DocumentIngestionOrchestratorTest {
         // then
         verify(documentStorageService).markDocumentsInActive(any());
         verify(documentIngestionOutcomeTableService).recordOutcomeFenced(
+                null,
                 documentId,
                 "INGESTION_SUCCESS",
                 "Document ingestion completed successfully",
@@ -190,14 +192,14 @@ class DocumentIngestionOrchestratorTest {
         );
 
         doThrow(new EntityRetrievalException("DB write error!"))
-                .when(documentIngestionOutcomeTableService).getDocumentById(documentId);
+                .when(documentIngestionOutcomeTableService).getDocumentById(null, documentId);
 
         // when
         final DocumentProcessingException ex = assertThrows(
                 DocumentProcessingException.class, () -> orchestrator.processQueueMessage(metadata, TOKEN));
 
         assertThat(ex.getMessage().contains("Unable to mark documents as Inactive in search index which were to be superseded by document with ID: " + documentId), is(true));
-        verify(documentIngestionOutcomeTableService, times(0)).recordOutcomeFenced(anyString(), anyString(), anyString(), anyString());
+        verify(documentIngestionOutcomeTableService, times(0)).recordOutcomeFenced(any(), anyString(), anyString(), anyString(), anyString());
     }
 
 
@@ -213,13 +215,14 @@ class DocumentIngestionOrchestratorTest {
                 "2025-10-07T15:45:30.987654Z"
         );
 
-        doNothing().when(documentIngestionOutcomeTableService).recordOutcomeFenced(anyString(), anyString(), anyString(), anyString());
+        doNothing().when(documentIngestionOutcomeTableService).recordOutcomeFenced(any(), anyString(), anyString(), anyString(), anyString());
 
         // when
         orchestrator.processQueueMessage(metadata, TOKEN);
 
         // then
         verify(documentIngestionOutcomeTableService).recordOutcomeFenced(
+                null,
                 "789e0123-f456-7890-abcd-ef1234567890",
                 "INGESTION_SUCCESS",
                 "Document ingestion completed successfully",
@@ -239,7 +242,7 @@ class DocumentIngestionOrchestratorTest {
         );
 
         doThrow(new EtagMismatchException("etag changed"))
-                .when(documentIngestionOutcomeTableService).recordOutcomeFenced(anyString(), anyString(), anyString(), anyString());
+                .when(documentIngestionOutcomeTableService).recordOutcomeFenced(any(), anyString(), anyString(), anyString(), anyString());
 
         // when & then
         assertThrows(EtagMismatchException.class, () -> orchestrator.processQueueMessage(metadata, TOKEN));
@@ -263,6 +266,7 @@ class DocumentIngestionOrchestratorTest {
 
         // then
         verify(documentIngestionOutcomeTableService).recordOutcomeFenced(
+                null,
                 "123e4567-e89b-12d3-a456-426614174000",
                 "INGESTION_FAILED",
                 "Document ingestion failed during processing",
@@ -281,7 +285,7 @@ class DocumentIngestionOrchestratorTest {
                 "https://storage.blob.core.windows.net/documents/Burglary-IDPC.pdf",
                 Instant.now().toString()
         );
-        when(documentIngestionOutcomeTableService.readForClaim("123e4567-e89b-12d3-a456-426614174000"))
+        when(documentIngestionOutcomeTableService.readForClaim(null, "123e4567-e89b-12d3-a456-426614174000"))
                 .thenReturn(new LeaseSnapshot("AWAITING_INGESTION", "W/\"fresh\"", null, null));
         when(documentIngestionOutcomeTableService.isTerminal("AWAITING_INGESTION")).thenReturn(false);
 
@@ -290,6 +294,7 @@ class DocumentIngestionOrchestratorTest {
 
         // then
         verify(documentIngestionOutcomeTableService).recordOutcomeFenced(
+                null,
                 "123e4567-e89b-12d3-a456-426614174000",
                 "INGESTION_FAILED",
                 "Document ingestion failed during processing",
@@ -308,7 +313,7 @@ class DocumentIngestionOrchestratorTest {
                 "https://storage.blob.core.windows.net/documents/Burglary-IDPC.pdf",
                 Instant.now().toString()
         );
-        when(documentIngestionOutcomeTableService.readForClaim("123e4567-e89b-12d3-a456-426614174000"))
+        when(documentIngestionOutcomeTableService.readForClaim(null, "123e4567-e89b-12d3-a456-426614174000"))
                 .thenReturn(new LeaseSnapshot("INGESTION_SUCCESS", "W/\"fresh\"", null, null));
         when(documentIngestionOutcomeTableService.isTerminal("INGESTION_SUCCESS")).thenReturn(true);
 
@@ -316,7 +321,7 @@ class DocumentIngestionOrchestratorTest {
         orchestrator.processQueueMessageFailedIfSafe(metadata);
 
         // then
-        verify(documentIngestionOutcomeTableService, times(0)).recordOutcomeFenced(anyString(), anyString(), anyString(), anyString());
+        verify(documentIngestionOutcomeTableService, times(0)).recordOutcomeFenced(any(), anyString(), anyString(), anyString(), anyString());
     }
 
     @Test
@@ -331,7 +336,7 @@ class DocumentIngestionOrchestratorTest {
                 "https://storage.blob.core.windows.net/documents/Burglary-IDPC.pdf",
                 Instant.now().toString()
         );
-        when(documentIngestionOutcomeTableService.readForClaim("123e4567-e89b-12d3-a456-426614174000"))
+        when(documentIngestionOutcomeTableService.readForClaim(null, "123e4567-e89b-12d3-a456-426614174000"))
                 .thenReturn(new LeaseSnapshot("AWAITING_INGESTION", "W/\"fresh\"",
                         java.time.OffsetDateTime.now().plusMinutes(5), "other-worker"));
         when(documentIngestionOutcomeTableService.isTerminal("AWAITING_INGESTION")).thenReturn(false);
@@ -340,7 +345,7 @@ class DocumentIngestionOrchestratorTest {
         orchestrator.processQueueMessageFailedIfSafe(metadata);
 
         // then
-        verify(documentIngestionOutcomeTableService, times(0)).recordOutcomeFenced(anyString(), anyString(), anyString(), anyString());
+        verify(documentIngestionOutcomeTableService, times(0)).recordOutcomeFenced(any(), anyString(), anyString(), anyString(), anyString());
     }
 
     @Test
@@ -356,11 +361,12 @@ class DocumentIngestionOrchestratorTest {
         );
 
         doThrow(new EtagMismatchException("etag changed"))
-                .when(documentIngestionOutcomeTableService).recordOutcomeFenced(any(), any(), any(), any());
+                .when(documentIngestionOutcomeTableService).recordOutcomeFenced(any(), any(), any(), any(), any());
 
         assertDoesNotThrow(() -> orchestrator.processQueueMessageFailed(metadata, TOKEN));
 
         verify(documentIngestionOutcomeTableService).recordOutcomeFenced(
+                null,
                 "123e4567-e89b-12d3-a456-426614174000",
                 "INGESTION_FAILED",
                 "Document ingestion failed during processing",
@@ -380,7 +386,7 @@ class DocumentIngestionOrchestratorTest {
         );
 
         doThrow(new RuntimeException("DB write error!"))
-                .when(documentIngestionOutcomeTableService).recordOutcomeFenced(any(), any(), any(), any());
+                .when(documentIngestionOutcomeTableService).recordOutcomeFenced(any(), any(), any(), any(), any());
 
         assertThrows(DocumentProcessingException.class, () -> orchestrator.processQueueMessageFailed(metadata, TOKEN));
     }

--- a/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/DocumentUploadFunction.java
+++ b/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/DocumentUploadFunction.java
@@ -111,7 +111,7 @@ public class DocumentUploadFunction {
 
             LOGGER.info("Initiating document upload for the documentId: {} documentName: {} supersededDocuments: {}", documentId, documentName, supersededDocuments);
 
-            if (documentUploadService.isDocumentAlreadyProcessed(documentId)) {
+            if (documentUploadService.isDocumentAlreadyProcessed(null, documentId)) {
                 final String errorMessage = "An upload request has already been initiated for documentId: " + documentId;
                 return generateResponse(request, HttpStatus.BAD_REQUEST, convert(new RequestErrored(errorMessage)));
             }

--- a/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/service/DocumentUploadService.java
+++ b/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/service/DocumentUploadService.java
@@ -44,8 +44,8 @@ public class DocumentUploadService {
     /**
      * Check if documentId already recorded in Table Storage.
      */
-    public boolean isDocumentAlreadyProcessed(final String documentId) {
-        final DocumentIngestionOutcome firstDocumentMatching = getDocument(documentId);
+    public boolean isDocumentAlreadyProcessed(final String clientId, final String documentId) {
+        final DocumentIngestionOutcome firstDocumentMatching = getDocument(clientId, documentId);
         if (nonNull(firstDocumentMatching)) {
             LOGGER.info("Document '{}' is already processed and has status '{}'.", documentId, firstDocumentMatching.getStatus());
             return true;
@@ -59,22 +59,29 @@ public class DocumentUploadService {
     public void addDocumentAwaitingUpload(final String documentId, final String documentName, final Map<String, String> metadataMap,
                                           final String supersededDocuments) throws DuplicateRecordException {
         final String metadataString = convert(metadataMap);
-        documentIngestionOutcomeTableService.insert(documentId, documentName, metadataString, supersededDocuments, AWAITING_UPLOAD.name(), AWAITING_UPLOAD_REASON);
+        documentIngestionOutcomeTableService.insert(null, documentId, documentName, metadataString, supersededDocuments, AWAITING_UPLOAD.name(), AWAITING_UPLOAD_REASON);
     }
 
     /**
      * upsert the document record in the table storage with status AWAITING_INGESTION.
      */
     public void updateDocumentAwaitingIngestion(final String documentId) {
-        documentIngestionOutcomeTableService.upsertDocument(documentId, AWAITING_INGESTION.name(), AWAITING_INGESTION_REASON);
+        documentIngestionOutcomeTableService.upsertDocument(null, documentId, AWAITING_INGESTION.name(), AWAITING_INGESTION_REASON);
     }
 
     /**
-     * Get Document by documentId from the Table Storage.
+     * Get Document by documentId from the Table Storage (legacy keying).
      */
     public DocumentIngestionOutcome getDocument(final String documentId) {
+        return getDocument(null, documentId);
+    }
+
+    /**
+     * Get Document by the {@code (clientId, documentId)} pair from the Table Storage.
+     */
+    public DocumentIngestionOutcome getDocument(final String clientId, final String documentId) {
         try {
-            return documentIngestionOutcomeTableService.getDocumentById(documentId);
+            return documentIngestionOutcomeTableService.getDocumentById(clientId, documentId);
         } catch (EntityRetrievalException e) {
             throw new DataRetrievalException("Unable to check status of document in table storage", e);
         }
@@ -84,7 +91,7 @@ public class DocumentUploadService {
      * upsert the document record in the table storage with status FILE_SIZE_OVER_LIMIT and reason to include blobSize and maxFileSizeLimit.
      */
     public void updateDocumentFileSizeOverLimit(final String documentId, final long documentSize, final long maxFileSizeLimit) {
-        documentIngestionOutcomeTableService.upsertDocument(documentId, FILE_SIZE_OVER_LIMIT.name(),
+        documentIngestionOutcomeTableService.upsertDocument(null, documentId, FILE_SIZE_OVER_LIMIT.name(),
                 format(FILE_SIZE_OVER_LIMIT_REASON, documentSize, maxFileSizeLimit));
     }
 }

--- a/ai-document-metadata-check-function/src/test/java/uk/gov/moj/cp/metadata/check/DocumentUploadFunctionTest.java
+++ b/ai-document-metadata-check-function/src/test/java/uk/gov/moj/cp/metadata/check/DocumentUploadFunctionTest.java
@@ -86,7 +86,7 @@ public class DocumentUploadFunctionTest {
         final DocumentUploadRequest body = validRequest();
 
         when(request.getBody()).thenReturn(body);
-        when(documentUploadService.isDocumentAlreadyProcessed(body.getDocumentId())).thenReturn(true);
+        when(documentUploadService.isDocumentAlreadyProcessed(null, body.getDocumentId())).thenReturn(true);
         mockResponseBuilder(HttpStatus.BAD_REQUEST);
 
         final HttpResponseMessage result = function.run(request, context);
@@ -101,7 +101,7 @@ public class DocumentUploadFunctionTest {
         final DocumentUploadRequest body = validRequest();
 
         when(request.getBody()).thenReturn(body);
-        when(documentUploadService.isDocumentAlreadyProcessed(body.getDocumentId())).thenReturn(false);
+        when(documentUploadService.isDocumentAlreadyProcessed(null, body.getDocumentId())).thenReturn(false);
         when(documentBlobNameResolver.getBlobName(any(String.class), any(String.class))).thenReturn("blobName");
         when(blobClientService.getSasUrl(any(String.class), anyInt())).thenReturn("http://sas-url");
         mockResponseBuilder(HttpStatus.OK);
@@ -121,7 +121,7 @@ public class DocumentUploadFunctionTest {
         body.setOverwrites(List.of(doc1.toString(), doc2.toString()));
 
         when(request.getBody()).thenReturn(body);
-        when(documentUploadService.isDocumentAlreadyProcessed(body.getDocumentId())).thenReturn(false);
+        when(documentUploadService.isDocumentAlreadyProcessed(null, body.getDocumentId())).thenReturn(false);
         when(documentBlobNameResolver.getBlobName(any(String.class), any(String.class))).thenReturn("blobName");
         when(blobClientService.getSasUrl(any(String.class), anyInt())).thenReturn("http://sas-url");
         mockResponseBuilder(HttpStatus.OK);
@@ -138,7 +138,7 @@ public class DocumentUploadFunctionTest {
         final DocumentUploadRequest body = validRequest();
 
         when(request.getBody()).thenReturn(body);
-        when(documentUploadService.isDocumentAlreadyProcessed(body.getDocumentId())).thenReturn(false);
+        when(documentUploadService.isDocumentAlreadyProcessed(null, body.getDocumentId())).thenReturn(false);
         when(blobClientService.getSasUrl(any(String.class), anyInt())).thenReturn("http://sas-url");
         when(documentBlobNameResolver.getBlobName(any(String.class), any(String.class))).thenReturn("blobName");
 
@@ -156,7 +156,7 @@ public class DocumentUploadFunctionTest {
         final DocumentUploadRequest body = validRequest();
 
         when(request.getBody()).thenReturn(body);
-        when(documentUploadService.isDocumentAlreadyProcessed(body.getDocumentId())).thenReturn(false);
+        when(documentUploadService.isDocumentAlreadyProcessed(null, body.getDocumentId())).thenReturn(false);
         when(documentBlobNameResolver.getBlobName(any(String.class), any(String.class))).thenReturn("documentId_date.pdf");
         when(blobClientService.getSasUrl(blobNameCaptor.capture(), anyInt())).thenReturn("http://sas-url");
         mockResponseBuilder(HttpStatus.OK);
@@ -173,7 +173,7 @@ public class DocumentUploadFunctionTest {
         final DocumentUploadRequest body = validRequest();
 
         when(request.getBody()).thenReturn(body);
-        when(documentUploadService.isDocumentAlreadyProcessed(any())).thenThrow(new RuntimeException("boom"));
+        when(documentUploadService.isDocumentAlreadyProcessed(any(), any())).thenThrow(new RuntimeException("boom"));
         mockResponseBuilder(HttpStatus.INTERNAL_SERVER_ERROR);
 
         HttpResponseMessage result = function.run(request, context);

--- a/ai-document-metadata-check-function/src/test/java/uk/gov/moj/cp/metadata/check/service/DocumentUploadServiceTest.java
+++ b/ai-document-metadata-check-function/src/test/java/uk/gov/moj/cp/metadata/check/service/DocumentUploadServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -47,33 +48,33 @@ public class DocumentUploadServiceTest {
 
         final DocumentIngestionOutcome outcome = mock(DocumentIngestionOutcome.class);
         when(outcome.getStatus()).thenReturn("COMPLETED");
-        when(tableService.getDocumentById(documentId)).thenReturn(outcome);
+        when(tableService.getDocumentById(null, documentId)).thenReturn(outcome);
 
-        final boolean result = documentUploadService.isDocumentAlreadyProcessed(documentId);
+        final boolean result = documentUploadService.isDocumentAlreadyProcessed(null, documentId);
 
         assertThat(result, is(true));
-        verify(tableService).getDocumentById(documentId);
+        verify(tableService).getDocumentById(null, documentId);
     }
 
     @Test
     void shouldReturnFalse_whenDocumentDoesNotExist() throws Exception {
         final String documentId = "doc-123";
 
-        when(tableService.getDocumentById(documentId)).thenReturn(null);
+        when(tableService.getDocumentById(null, documentId)).thenReturn(null);
 
-        final boolean result = documentUploadService.isDocumentAlreadyProcessed(documentId);
+        final boolean result = documentUploadService.isDocumentAlreadyProcessed(null, documentId);
 
         assertThat(result, is(false));
-        verify(tableService).getDocumentById(documentId);
+        verify(tableService).getDocumentById(null, documentId);
     }
 
     @Test
     void shouldThrowDataRetrievalException_whenEntityRetrievalFails() throws Exception {
         final String documentId = "doc-123";
 
-        when(tableService.getDocumentById(documentId)).thenThrow(new EntityRetrievalException("error"));
+        when(tableService.getDocumentById(null, documentId)).thenThrow(new EntityRetrievalException("error"));
 
-        assertThrows(DataRetrievalException.class, () -> documentUploadService.isDocumentAlreadyProcessed(documentId));
+        assertThrows(DataRetrievalException.class, () -> documentUploadService.isDocumentAlreadyProcessed(null, documentId));
     }
 
     @Test
@@ -85,7 +86,7 @@ public class DocumentUploadServiceTest {
 
         documentUploadService.addDocumentAwaitingUpload(documentId, documentName, metadataMap, supersededDocuments);
 
-        verify(tableService).insert(eq(documentId), eq(documentName), eq("{\"k1\":\"v1\"}"), eq(supersededDocuments), eq(AWAITING_UPLOAD.name()), eq(AWAITING_UPLOAD_REASON));
+        verify(tableService).insert(isNull(), eq(documentId), eq(documentName), eq("{\"k1\":\"v1\"}"), eq(supersededDocuments), eq(AWAITING_UPLOAD.name()), eq(AWAITING_UPLOAD_REASON));
     }
 
     @Test
@@ -96,7 +97,7 @@ public class DocumentUploadServiceTest {
 
         documentUploadService.updateDocumentFileSizeOverLimit(documentId, documentSize, maxFileSize);
 
-        verify(tableService).upsertDocument(documentId, FILE_SIZE_OVER_LIMIT.name(), "Document Uploaded with size=1500 is over the configured size limit=1200");
+        verify(tableService).upsertDocument(null, documentId, FILE_SIZE_OVER_LIMIT.name(), "Document Uploaded with size=1500 is over the configured size limit=1200");
     }
 
     @Test
@@ -106,10 +107,23 @@ public class DocumentUploadServiceTest {
         final Map<String, String> metadataMap = Map.of("k1", "v1");
         final String supersededDocuments = "doc1,doc2";
 
-        doThrow(new DuplicateRecordException("duplicate")).when(tableService).insert(any(), any(), any(), any(), any(), any());
+        doThrow(new DuplicateRecordException("duplicate")).when(tableService).insert(any(), any(), any(), any(), any(), any(), any());
 
         assertThrows(DuplicateRecordException.class, () -> documentUploadService.addDocumentAwaitingUpload(documentId, documentName, metadataMap, supersededDocuments));
 
-        verify(tableService).insert(eq(documentId), eq(documentName), anyString(), anyString(),anyString(), anyString());
+        verify(tableService).insert(isNull(), eq(documentId), eq(documentName), anyString(), anyString(),anyString(), anyString());
+    }
+
+    @Test
+    void shouldScopeDedupLookupToTheSuppliedClient() throws Exception {
+        final String clientId = "11111111-1111-1111-1111-111111111111";
+        final String documentId = "doc-123";
+        final DocumentIngestionOutcome outcome = mock(DocumentIngestionOutcome.class);
+        when(tableService.getDocumentById(clientId, documentId)).thenReturn(outcome);
+
+        final boolean result = documentUploadService.isDocumentAlreadyProcessed(clientId, documentId);
+
+        assertThat(result, is(true));
+        verify(tableService).getDocumentById(clientId, documentId);
     }
 }

--- a/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/idempotency/ClaimToken.java
+++ b/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/idempotency/ClaimToken.java
@@ -4,6 +4,9 @@ package uk.gov.moj.cp.ai.idempotency;
  * Proof of a successfully claimed in-progress lease. The {@code etag} is the fencing token:
  * every terminal status write must be conditioned on it, so a worker whose lease has since
  * been reclaimed (its etag is stale) cannot overwrite the outcome.
+ * <p>
+ * {@code clientId} carries the owning namespace so a fenced terminal write targets the correct
+ * partition. A null {@code clientId} means legacy keying (partition == key).
  */
-public record ClaimToken(String key, String etag) {
+public record ClaimToken(String clientId, String key, String etag) {
 }

--- a/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/idempotency/IdempotencyGuard.java
+++ b/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/idempotency/IdempotencyGuard.java
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
 /**
  * Effectively-once guard for queue-triggered work (design: docs/idempotency-rag-service.md).
  * <p>
- * {@code runOnce(key, work)} reads the status row for the key; skips if the status is already
+ * {@code runOnce(clientId, key, work)} reads the status row for the (clientId, key); skips if the status is already
  * terminal; otherwise claims an in-progress lease via an ETag-conditioned write (the first
  * worker wins, a concurrent duplicate loses with {@link LeaseConflictException}) and runs the
  * work with a {@link ClaimToken}. The token's ETag fences the work's terminal write: a worker
@@ -49,8 +49,8 @@ public class IdempotencyGuard {
      * @throws Exception              whatever the work throws; the lease is released first so
      *                                the next delivery can re-claim immediately
      */
-    public GuardOutcome runOnce(final String key, final IdempotentWork work) throws Exception {
-        final ClaimToken token = claim(key);
+    public GuardOutcome runOnce(final String clientId, final String key, final IdempotentWork work) throws Exception {
+        final ClaimToken token = claim(clientId, key);
         if (token == null) {
             return GuardOutcome.SKIPPED_TERMINAL;
         }
@@ -61,7 +61,7 @@ public class IdempotencyGuard {
             // On a fence loss the claim etag is already stale — a release would be a
             // guaranteed 412 and only produce a misleading "release failed" warning.
             if (!(e instanceof EtagMismatchException)) {
-                store.releaseLease(key, token.etag());
+                store.releaseLease(clientId, key, token.etag());
             }
             throw e;
         }
@@ -69,18 +69,18 @@ public class IdempotencyGuard {
     }
 
     /** Returns the winning claim, or {@code null} when the row is terminal (skip). */
-    private ClaimToken claim(final String key) throws EntityRetrievalException {
+    private ClaimToken claim(final String clientId, final String key) throws EntityRetrievalException {
         final String owner = UUID.randomUUID().toString();
 
-        LeaseSnapshot snapshot = store.readForClaim(key);
+        LeaseSnapshot snapshot = store.readForClaim(clientId, key);
 
         if (snapshot == null) {
             try {
-                final String etag = store.createClaimedRow(key, owner, expiry());
+                final String etag = store.createClaimedRow(clientId, key, owner, expiry());
                 LOGGER.warn("Status row was missing for key={} — created claimed row defensively", key);
-                return new ClaimToken(key, etag);
+                return new ClaimToken(clientId, key, etag);
             } catch (DuplicateRecordException e) {
-                snapshot = store.readForClaim(key);
+                snapshot = store.readForClaim(clientId, key);
                 if (snapshot == null) {
                     throw new LeaseConflictException("Status row for key '" + key + "' appeared then vanished during claim", e);
                 }
@@ -99,9 +99,9 @@ public class IdempotencyGuard {
         }
 
         try {
-            final String etag = store.claimLease(key, snapshot.etag(), owner, expiry());
+            final String etag = store.claimLease(clientId, key, snapshot.etag(), owner, expiry());
             LOGGER.info("Claimed idempotency lease for key={} (owner={})", key, owner);
-            return new ClaimToken(key, etag);
+            return new ClaimToken(clientId, key, etag);
         } catch (EtagMismatchException e) {
             throw new LeaseConflictException("Lost the claim race for key '" + key + "'", e);
         }

--- a/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/idempotency/IdempotencyStatusStore.java
+++ b/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/idempotency/IdempotencyStatusStore.java
@@ -10,8 +10,9 @@ import java.time.ZoneOffset;
 
 /**
  * Flow-specific persistence operations the {@link IdempotencyGuard} needs against a status
- * table whose rows are keyed PartitionKey == RowKey == key. Implemented by the existing
- * status-table services.
+ * table. Rows are keyed on {@code (clientId, key)}: the partition key is the {@code clientId}
+ * namespace and the row key is the {@code key}. A null or blank {@code clientId} means legacy
+ * keying (PartitionKey == RowKey == key). Implemented by the existing status-table services.
  */
 public interface IdempotencyStatusStore {
 
@@ -21,8 +22,8 @@ public interface IdempotencyStatusStore {
      */
     OffsetDateTime LEASE_RELEASED = Instant.EPOCH.atOffset(ZoneOffset.UTC);
 
-    /** Current status/etag/lease state for the key, or {@code null} if the row is missing. */
-    LeaseSnapshot readForClaim(String key) throws EntityRetrievalException;
+    /** Current status/etag/lease state for the (clientId, key) row, or {@code null} if the row is missing. */
+    LeaseSnapshot readForClaim(String clientId, String key) throws EntityRetrievalException;
 
     /** Whether this status value means the work is already done (success or exhausted failure). */
     boolean isTerminal(String status);
@@ -33,7 +34,7 @@ public interface IdempotencyStatusStore {
      * @return the row's new ETag — the winner's fencing token
      * @throws EtagMismatchException if another worker changed the row first (claim lost)
      */
-    String claimLease(String key, String expectedEtag, String owner, OffsetDateTime expiresAt);
+    String claimLease(String clientId, String key, String expectedEtag, String owner, OffsetDateTime expiresAt);
 
     /**
      * Defensive path for a missing status row: creates a minimal non-terminal row with the
@@ -41,12 +42,12 @@ public interface IdempotencyStatusStore {
      *
      * @return the created row's ETag
      */
-    String createClaimedRow(String key, String owner, OffsetDateTime expiresAt) throws DuplicateRecordException;
+    String createClaimedRow(String clientId, String key, String owner, OffsetDateTime expiresAt) throws DuplicateRecordException;
 
     /**
      * Best-effort release: marks the lease reclaimable ({@link #LEASE_RELEASED}) via a
      * conditional write on {@code etag}. A rejection (someone reclaimed) or any other
      * failure is swallowed — the lease then simply expires by TTL.
      */
-    void releaseLease(String key, String etag);
+    void releaseLease(String clientId, String key, String etag);
 }

--- a/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/service/table/AnswerGenerationTableService.java
+++ b/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/service/table/AnswerGenerationTableService.java
@@ -48,11 +48,11 @@ public class AnswerGenerationTableService implements IdempotencyStatusStore {
         this.tableService = tableService;
     }
 
-    public void saveAnswerGenerationRequest(final String transactionId, final String userQuery,
+    public void saveAnswerGenerationRequest(final String clientId, final String transactionId, final String userQuery,
                                             final String queryPrompt, final AnswerGenerationStatus status) throws DuplicateRecordException {
 
         final TableEntity entity = buildEntity(
-                transactionId, userQuery, queryPrompt,
+                clientId, transactionId, userQuery, queryPrompt,
                 null, null, status,
                 null, null, null
         );
@@ -68,6 +68,7 @@ public class AnswerGenerationTableService implements IdempotencyStatusStore {
     ) {
 
         final TableEntity entity = buildEntity(
+                null,
                 transactionId,
                 userQuery,
                 queryPrompt,
@@ -84,9 +85,9 @@ public class AnswerGenerationTableService implements IdempotencyStatusStore {
         LOGGER.info("Answer generation record UPSERTED with status={} for transactionId={}", status, transactionId);
     }
 
-    public GeneratedAnswer getGeneratedAnswer(final String transactionId) throws EntityRetrievalException {
+    public GeneratedAnswer getGeneratedAnswer(final String clientId, final String transactionId) throws EntityRetrievalException {
 
-        final TableEntity entity = tableService.getFirstDocumentMatching(transactionId, transactionId);
+        final TableEntity entity = tableService.getFirstDocumentMatching(partitionKey(clientId, transactionId), transactionId);
         if (null == entity) {
             return null;
         }
@@ -105,8 +106,8 @@ public class AnswerGenerationTableService implements IdempotencyStatusStore {
 
     }
 
-    public void recordGroundednessScore(final String transactionId, final BigDecimal bigDecimal) {
-        final TableEntity entity = new TableEntity(transactionId, transactionId);
+    public void recordGroundednessScore(final String clientId, final String transactionId, final BigDecimal bigDecimal) {
+        final TableEntity entity = new TableEntity(partitionKey(clientId, transactionId), transactionId);
         entity.addProperty(TC_RESPONSE_GROUNDEDNESS_SCORE, bigDecimal);
         tableService.upsertIntoTable(entity);
     }
@@ -116,13 +117,14 @@ public class AnswerGenerationTableService implements IdempotencyStatusStore {
      * MERGE) — the fenced terminal write of the idempotency guard. Throws
      * {@link uk.gov.moj.cp.ai.exception.EtagMismatchException} if the lease was reclaimed.
      */
-    public void upsertTerminalFenced(final String transactionId, final String userQuery,
+    public void upsertTerminalFenced(final String clientId, final String transactionId, final String userQuery,
                                      final String queryPrompt, final String chunkedEntriesFile, final String llmResponse,
                                      final AnswerGenerationStatus status, final String reason,
                                      final OffsetDateTime responseGenerationTime, final Long responseGenerationDuration,
                                      final String etag
     ) {
         final TableEntity entity = buildEntity(
+                clientId,
                 transactionId,
                 userQuery,
                 queryPrompt,
@@ -140,8 +142,8 @@ public class AnswerGenerationTableService implements IdempotencyStatusStore {
     }
 
     @Override
-    public LeaseSnapshot readForClaim(final String key) throws EntityRetrievalException {
-        final TableEntity entity = tableService.getFirstDocumentMatching(key, key);
+    public LeaseSnapshot readForClaim(final String clientId, final String key) throws EntityRetrievalException {
+        final TableEntity entity = tableService.getFirstDocumentMatching(partitionKey(clientId, key), key);
         if (null == entity) {
             return null;
         }
@@ -160,16 +162,16 @@ public class AnswerGenerationTableService implements IdempotencyStatusStore {
     }
 
     @Override
-    public String claimLease(final String key, final String expectedEtag, final String owner, final OffsetDateTime expiresAt) {
-        final TableEntity entity = new TableEntity(key, key);
+    public String claimLease(final String clientId, final String key, final String expectedEtag, final String owner, final OffsetDateTime expiresAt) {
+        final TableEntity entity = new TableEntity(partitionKey(clientId, key), key);
         entity.addProperty(TC_LEASE_OWNER, owner);
         entity.addProperty(TC_LEASE_EXPIRES_AT, expiresAt);
         return tableService.updateEntityIfUnchanged(entity, expectedEtag);
     }
 
     @Override
-    public String createClaimedRow(final String key, final String owner, final OffsetDateTime expiresAt) throws DuplicateRecordException {
-        final TableEntity entity = new TableEntity(key, key);
+    public String createClaimedRow(final String clientId, final String key, final String owner, final OffsetDateTime expiresAt) throws DuplicateRecordException {
+        final TableEntity entity = new TableEntity(partitionKey(clientId, key), key);
         entity.addProperty(TC_TRANSACTION_ID, key);
         entity.addProperty(TC_ANSWER_STATUS, AnswerGenerationStatus.ANSWER_GENERATION_PENDING.name());
         entity.addProperty(TC_LEASE_OWNER, owner);
@@ -178,9 +180,9 @@ public class AnswerGenerationTableService implements IdempotencyStatusStore {
     }
 
     @Override
-    public void releaseLease(final String key, final String etag) {
+    public void releaseLease(final String clientId, final String key, final String etag) {
         try {
-            final TableEntity entity = new TableEntity(key, key);
+            final TableEntity entity = new TableEntity(partitionKey(clientId, key), key);
             entity.addProperty(TC_LEASE_EXPIRES_AT, LEASE_RELEASED);
             tableService.updateEntityIfUnchanged(entity, etag);
         } catch (Exception e) {
@@ -189,6 +191,7 @@ public class AnswerGenerationTableService implements IdempotencyStatusStore {
     }
 
     private TableEntity buildEntity(
+            final String clientId,
             final String transactionId,
             final String userQuery,
             final String queryPrompt,
@@ -199,7 +202,7 @@ public class AnswerGenerationTableService implements IdempotencyStatusStore {
             final OffsetDateTime responseGenerationTime,
             final Long responseGenerationDuration
     ) {
-        final TableEntity entity = new TableEntity(transactionId, transactionId);
+        final TableEntity entity = new TableEntity(partitionKey(clientId, transactionId), transactionId);
 
         entity.addProperty(TC_TRANSACTION_ID, transactionId);
         entity.addProperty(TC_USER_QUERY, userQuery);
@@ -220,5 +223,13 @@ public class AnswerGenerationTableService implements IdempotencyStatusStore {
 
     private Long getPropertyAsLong(final Object value) {
         return value instanceof Number number ? number.longValue() : null;
+    }
+
+    /**
+     * Effective partition key for a {@code (clientId, key)} row. Keys on the row key only for now;
+     * a subsequent change swaps in {@code clientId} as the partition when it is present.
+     */
+    private static String partitionKey(final String clientId, final String key) {
+        return key;
     }
 }

--- a/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/service/table/AnswerGenerationTableService.java
+++ b/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/service/table/AnswerGenerationTableService.java
@@ -226,10 +226,11 @@ public class AnswerGenerationTableService implements IdempotencyStatusStore {
     }
 
     /**
-     * Effective partition key for a {@code (clientId, key)} row. Keys on the row key only for now;
-     * a subsequent change swaps in {@code clientId} as the partition when it is present.
+     * Effective partition key for a {@code (clientId, key)} row. When a {@code clientId} is present
+     * it becomes the partition, isolating rows per client; a null or blank {@code clientId} falls
+     * back to the row key as the partition (legacy PK == RK == key layout).
      */
     private static String partitionKey(final String clientId, final String key) {
-        return key;
+        return isNullOrEmpty(clientId) ? key : clientId;
     }
 }

--- a/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/service/table/DocumentIngestionOutcomeTableService.java
+++ b/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/service/table/DocumentIngestionOutcomeTableService.java
@@ -151,11 +151,12 @@ public class DocumentIngestionOutcomeTableService implements IdempotencyStatusSt
     }
 
     /**
-     * Effective partition key for a {@code (clientId, key)} row. Keys on the row key only for now;
-     * a subsequent change swaps in {@code clientId} as the partition when it is present.
+     * Effective partition key for a {@code (clientId, key)} row. When a {@code clientId} is present
+     * it becomes the partition, isolating rows per client; a null or blank {@code clientId} falls
+     * back to the row key as the partition (legacy PK == RK == key layout).
      */
     private static String partitionKey(final String clientId, final String key) {
-        return key;
+        return isNullOrEmpty(clientId) ? key : clientId;
     }
 
     private String getPropertyAsString(final Object value) {

--- a/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/service/table/DocumentIngestionOutcomeTableService.java
+++ b/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/service/table/DocumentIngestionOutcomeTableService.java
@@ -45,9 +45,9 @@ public class DocumentIngestionOutcomeTableService implements IdempotencyStatusSt
         this.tableService = tableService;
     }
 
-    public void insert(final String documentId, final String documentName, final String metadata, final String supersededDocuments,
+    public void insert(final String clientId, final String documentId, final String documentName, final String metadata, final String supersededDocuments,
                        final String status, final String reason) throws DuplicateRecordException {
-        final TableEntity entity = new TableEntity(documentId, documentId);
+        final TableEntity entity = new TableEntity(partitionKey(clientId, documentId), documentId);
         entity.addProperty(TC_DOCUMENT_FILE_NAME, documentName);
         entity.addProperty(TC_DOCUMENT_ID, documentId);
         entity.addProperty(TC_DOCUMENT_METADATA, metadata);
@@ -60,10 +60,10 @@ public class DocumentIngestionOutcomeTableService implements IdempotencyStatusSt
         LOGGER.info("Document upload record INSERTED into table with status '{}' for document '{}' with ID '{}'", status, documentName, documentId);
     }
 
-    public void upsertDocument(final String documentId, final String status, final String reason) {
+    public void upsertDocument(final String clientId, final String documentId, final String status, final String reason) {
 
         try {
-            final TableEntity entity = tableService.getFirstDocumentMatching(documentId, documentId);
+            final TableEntity entity = tableService.getFirstDocumentMatching(partitionKey(clientId, documentId), documentId);
 
             entity.addProperty(TC_DOCUMENT_STATUS, status);
             entity.addProperty(TC_REASON, reason);
@@ -82,8 +82,8 @@ public class DocumentIngestionOutcomeTableService implements IdempotencyStatusSt
      * no read-modify-write — MERGE preserves the other columns by definition. Throws
      * {@link uk.gov.moj.cp.ai.exception.EtagMismatchException} if the lease was reclaimed.
      */
-    public void recordOutcomeFenced(final String documentId, final String status, final String reason, final String etag) {
-        final TableEntity entity = new TableEntity(documentId, documentId);
+    public void recordOutcomeFenced(final String clientId, final String documentId, final String status, final String reason, final String etag) {
+        final TableEntity entity = new TableEntity(partitionKey(clientId, documentId), documentId);
         entity.addProperty(TC_DOCUMENT_STATUS, status);
         entity.addProperty(TC_REASON, reason);
 
@@ -93,8 +93,8 @@ public class DocumentIngestionOutcomeTableService implements IdempotencyStatusSt
     }
 
     @Override
-    public LeaseSnapshot readForClaim(final String key) throws EntityRetrievalException {
-        final TableEntity entity = tableService.getFirstDocumentMatching(key, key);
+    public LeaseSnapshot readForClaim(final String clientId, final String key) throws EntityRetrievalException {
+        final TableEntity entity = tableService.getFirstDocumentMatching(partitionKey(clientId, key), key);
         if (null == entity) {
             return null;
         }
@@ -114,16 +114,16 @@ public class DocumentIngestionOutcomeTableService implements IdempotencyStatusSt
     }
 
     @Override
-    public String claimLease(final String key, final String expectedEtag, final String owner, final OffsetDateTime expiresAt) {
-        final TableEntity entity = new TableEntity(key, key);
+    public String claimLease(final String clientId, final String key, final String expectedEtag, final String owner, final OffsetDateTime expiresAt) {
+        final TableEntity entity = new TableEntity(partitionKey(clientId, key), key);
         entity.addProperty(TC_LEASE_OWNER, owner);
         entity.addProperty(TC_LEASE_EXPIRES_AT, expiresAt);
         return tableService.updateEntityIfUnchanged(entity, expectedEtag);
     }
 
     @Override
-    public String createClaimedRow(final String key, final String owner, final OffsetDateTime expiresAt) throws DuplicateRecordException {
-        final TableEntity entity = new TableEntity(key, key);
+    public String createClaimedRow(final String clientId, final String key, final String owner, final OffsetDateTime expiresAt) throws DuplicateRecordException {
+        final TableEntity entity = new TableEntity(partitionKey(clientId, key), key);
         entity.addProperty(TC_DOCUMENT_ID, key);
         entity.addProperty(TC_DOCUMENT_STATUS, DocumentIngestionStatus.AWAITING_INGESTION.name());
         entity.addProperty(TC_LEASE_OWNER, owner);
@@ -132,9 +132,9 @@ public class DocumentIngestionOutcomeTableService implements IdempotencyStatusSt
     }
 
     @Override
-    public void releaseLease(final String key, final String etag) {
+    public void releaseLease(final String clientId, final String key, final String etag) {
         try {
-            final TableEntity entity = new TableEntity(key, key);
+            final TableEntity entity = new TableEntity(partitionKey(clientId, key), key);
             entity.addProperty(TC_LEASE_EXPIRES_AT, LEASE_RELEASED);
             tableService.updateEntityIfUnchanged(entity, etag);
         } catch (Exception e) {
@@ -142,12 +142,20 @@ public class DocumentIngestionOutcomeTableService implements IdempotencyStatusSt
         }
     }
 
-    public DocumentIngestionOutcome getDocumentById(String documentId) throws EntityRetrievalException {
-        final TableEntity entity = tableService.getFirstDocumentMatching(documentId, documentId);
+    public DocumentIngestionOutcome getDocumentById(final String clientId, final String documentId) throws EntityRetrievalException {
+        final TableEntity entity = tableService.getFirstDocumentMatching(partitionKey(clientId, documentId), documentId);
         if (null == entity) {
             return null;
         }
         return getDocumentIngestionOutcome(entity);
+    }
+
+    /**
+     * Effective partition key for a {@code (clientId, key)} row. Keys on the row key only for now;
+     * a subsequent change swaps in {@code clientId} as the partition when it is present.
+     */
+    private static String partitionKey(final String clientId, final String key) {
+        return key;
     }
 
     private String getPropertyAsString(final Object value) {

--- a/ai-document-shared-artefacts/src/test/java/uk/gov/moj/cp/ai/idempotency/IdempotencyGuardTest.java
+++ b/ai-document-shared-artefacts/src/test/java/uk/gov/moj/cp/ai/idempotency/IdempotencyGuardTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -50,74 +51,74 @@ class IdempotencyGuardTest {
     @Test
     @DisplayName("Skips without claiming when the row is already terminal")
     void skipsWhenTerminal() throws Exception {
-        when(store.readForClaim(KEY)).thenReturn(new LeaseSnapshot("DONE", READ_ETAG, null, null));
+        when(store.readForClaim(null, KEY)).thenReturn(new LeaseSnapshot("DONE", READ_ETAG, null, null));
         when(store.isTerminal("DONE")).thenReturn(true);
 
-        assertEquals(GuardOutcome.SKIPPED_TERMINAL, guard.runOnce(KEY, work));
+        assertEquals(GuardOutcome.SKIPPED_TERMINAL, guard.runOnce(null, KEY, work));
 
         verify(work, never()).run(any());
-        verify(store, never()).claimLease(anyString(), anyString(), anyString(), any());
+        verify(store, never()).claimLease(any(), anyString(), anyString(), anyString(), any());
     }
 
     @Test
     @DisplayName("Claims a free row (lease TTL from the clock) and runs the work with the claim token")
     void claimsFreeRowAndRunsWork() throws Exception {
-        when(store.readForClaim(KEY)).thenReturn(new LeaseSnapshot("PENDING", READ_ETAG, null, null));
+        when(store.readForClaim(null, KEY)).thenReturn(new LeaseSnapshot("PENDING", READ_ETAG, null, null));
         when(store.isTerminal("PENDING")).thenReturn(false);
-        when(store.claimLease(eq(KEY), eq(READ_ETAG), anyString(), eq(now().plus(TTL)))).thenReturn(CLAIM_ETAG);
+        when(store.claimLease(isNull(), eq(KEY), eq(READ_ETAG), anyString(), eq(now().plus(TTL)))).thenReturn(CLAIM_ETAG);
 
-        assertEquals(GuardOutcome.EXECUTED, guard.runOnce(KEY, work));
+        assertEquals(GuardOutcome.EXECUTED, guard.runOnce(null, KEY, work));
 
-        verify(work).run(new ClaimToken(KEY, CLAIM_ETAG));
-        verify(store, never()).releaseLease(anyString(), anyString());
+        verify(work).run(new ClaimToken(null, KEY, CLAIM_ETAG));
+        verify(store, never()).releaseLease(any(), anyString(), anyString());
     }
 
     @Test
     @DisplayName("Throws LeaseConflictException without claiming when a live lease exists")
     void throwsLeaseConflictWhenLiveLease() throws Exception {
-        when(store.readForClaim(KEY)).thenReturn(
+        when(store.readForClaim(null, KEY)).thenReturn(
                 new LeaseSnapshot("PENDING", READ_ETAG, now().plusMinutes(5), "other-owner"));
         when(store.isTerminal("PENDING")).thenReturn(false);
 
-        assertThrows(LeaseConflictException.class, () -> guard.runOnce(KEY, work));
+        assertThrows(LeaseConflictException.class, () -> guard.runOnce(null, KEY, work));
 
         verify(work, never()).run(any());
-        verify(store, never()).claimLease(anyString(), anyString(), anyString(), any());
+        verify(store, never()).claimLease(any(), anyString(), anyString(), anyString(), any());
     }
 
     @Test
     @DisplayName("Reclaims an expired lease via the conditional write")
     void reclaimsExpiredLease() throws Exception {
-        when(store.readForClaim(KEY)).thenReturn(
+        when(store.readForClaim(null, KEY)).thenReturn(
                 new LeaseSnapshot("PENDING", READ_ETAG, now().minusMinutes(5), "crashed-owner"));
         when(store.isTerminal("PENDING")).thenReturn(false);
-        when(store.claimLease(eq(KEY), eq(READ_ETAG), anyString(), any())).thenReturn(CLAIM_ETAG);
+        when(store.claimLease(isNull(), eq(KEY), eq(READ_ETAG), anyString(), any())).thenReturn(CLAIM_ETAG);
 
-        assertEquals(GuardOutcome.EXECUTED, guard.runOnce(KEY, work));
+        assertEquals(GuardOutcome.EXECUTED, guard.runOnce(null, KEY, work));
 
-        verify(work).run(new ClaimToken(KEY, CLAIM_ETAG));
+        verify(work).run(new ClaimToken(null, KEY, CLAIM_ETAG));
     }
 
     @Test
     @DisplayName("A lease expiring exactly now is reclaimable (not live)")
     void leaseExpiringExactlyNowIsReclaimable() throws Exception {
-        when(store.readForClaim(KEY)).thenReturn(
+        when(store.readForClaim(null, KEY)).thenReturn(
                 new LeaseSnapshot("PENDING", READ_ETAG, now(), "other-owner"));
         when(store.isTerminal("PENDING")).thenReturn(false);
-        when(store.claimLease(eq(KEY), eq(READ_ETAG), anyString(), any())).thenReturn(CLAIM_ETAG);
+        when(store.claimLease(isNull(), eq(KEY), eq(READ_ETAG), anyString(), any())).thenReturn(CLAIM_ETAG);
 
-        assertEquals(GuardOutcome.EXECUTED, guard.runOnce(KEY, work));
+        assertEquals(GuardOutcome.EXECUTED, guard.runOnce(null, KEY, work));
     }
 
     @Test
     @DisplayName("Losing the claim race (etag mismatch) surfaces as LeaseConflictException")
     void claimRaceLossSurfacesAsLeaseConflict() throws Exception {
-        when(store.readForClaim(KEY)).thenReturn(new LeaseSnapshot("PENDING", READ_ETAG, null, null));
+        when(store.readForClaim(null, KEY)).thenReturn(new LeaseSnapshot("PENDING", READ_ETAG, null, null));
         when(store.isTerminal("PENDING")).thenReturn(false);
-        when(store.claimLease(eq(KEY), eq(READ_ETAG), anyString(), any()))
+        when(store.claimLease(isNull(), eq(KEY), eq(READ_ETAG), anyString(), any()))
                 .thenThrow(new EtagMismatchException("etag changed"));
 
-        assertThrows(LeaseConflictException.class, () -> guard.runOnce(KEY, work));
+        assertThrows(LeaseConflictException.class, () -> guard.runOnce(null, KEY, work));
 
         verify(work, never()).run(any());
     }
@@ -125,72 +126,72 @@ class IdempotencyGuardTest {
     @Test
     @DisplayName("Releases the lease then rethrows when the work fails")
     void releasesLeaseAndRethrowsOnWorkFailure() throws Exception {
-        when(store.readForClaim(KEY)).thenReturn(new LeaseSnapshot("PENDING", READ_ETAG, null, null));
+        when(store.readForClaim(null, KEY)).thenReturn(new LeaseSnapshot("PENDING", READ_ETAG, null, null));
         when(store.isTerminal("PENDING")).thenReturn(false);
-        when(store.claimLease(eq(KEY), eq(READ_ETAG), anyString(), any())).thenReturn(CLAIM_ETAG);
+        when(store.claimLease(isNull(), eq(KEY), eq(READ_ETAG), anyString(), any())).thenReturn(CLAIM_ETAG);
 
         final RuntimeException failure = new RuntimeException("work failed");
         org.mockito.Mockito.doThrow(failure).when(work).run(any());
 
-        final RuntimeException thrown = assertThrows(RuntimeException.class, () -> guard.runOnce(KEY, work));
+        final RuntimeException thrown = assertThrows(RuntimeException.class, () -> guard.runOnce(null, KEY, work));
 
         assertSame(failure, thrown);
-        verify(store).releaseLease(KEY, CLAIM_ETAG);
+        verify(store).releaseLease(null, KEY, CLAIM_ETAG);
     }
 
     @Test
     @DisplayName("Does NOT release the lease when the work fails with a fence loss (etag already stale)")
     void doesNotReleaseLeaseOnFenceLoss() throws Exception {
-        when(store.readForClaim(KEY)).thenReturn(new LeaseSnapshot("PENDING", READ_ETAG, null, null));
+        when(store.readForClaim(null, KEY)).thenReturn(new LeaseSnapshot("PENDING", READ_ETAG, null, null));
         when(store.isTerminal("PENDING")).thenReturn(false);
-        when(store.claimLease(eq(KEY), eq(READ_ETAG), anyString(), any())).thenReturn(CLAIM_ETAG);
+        when(store.claimLease(isNull(), eq(KEY), eq(READ_ETAG), anyString(), any())).thenReturn(CLAIM_ETAG);
 
         org.mockito.Mockito.doThrow(new EtagMismatchException("etag changed")).when(work).run(any());
 
-        assertThrows(EtagMismatchException.class, () -> guard.runOnce(KEY, work));
+        assertThrows(EtagMismatchException.class, () -> guard.runOnce(null, KEY, work));
 
-        verify(store, never()).releaseLease(anyString(), anyString());
+        verify(store, never()).releaseLease(any(), anyString(), anyString());
     }
 
     @Test
     @DisplayName("Creates a claimed row defensively when the status row is missing")
     void createsClaimedRowWhenRowMissing() throws Exception {
-        when(store.readForClaim(KEY)).thenReturn(null);
-        when(store.createClaimedRow(eq(KEY), anyString(), eq(now().plus(TTL)))).thenReturn(CLAIM_ETAG);
+        when(store.readForClaim(null, KEY)).thenReturn(null);
+        when(store.createClaimedRow(isNull(), eq(KEY), anyString(), eq(now().plus(TTL)))).thenReturn(CLAIM_ETAG);
 
-        assertEquals(GuardOutcome.EXECUTED, guard.runOnce(KEY, work));
+        assertEquals(GuardOutcome.EXECUTED, guard.runOnce(null, KEY, work));
 
-        verify(work).run(new ClaimToken(KEY, CLAIM_ETAG));
-        verify(store, never()).claimLease(anyString(), anyString(), anyString(), any());
+        verify(work).run(new ClaimToken(null, KEY, CLAIM_ETAG));
+        verify(store, never()).claimLease(any(), anyString(), anyString(), anyString(), any());
     }
 
     @Test
     @DisplayName("Falls back to a re-read when the defensive insert races a concurrent creator")
     void reReadsWhenDefensiveInsertRacesConcurrentCreator() throws Exception {
-        when(store.readForClaim(KEY))
+        when(store.readForClaim(null, KEY))
                 .thenReturn(null)
                 .thenReturn(new LeaseSnapshot("PENDING", READ_ETAG, null, null));
-        when(store.createClaimedRow(eq(KEY), anyString(), any()))
+        when(store.createClaimedRow(isNull(), eq(KEY), anyString(), any()))
                 .thenThrow(new DuplicateRecordException("already exists"));
         when(store.isTerminal("PENDING")).thenReturn(false);
-        when(store.claimLease(eq(KEY), eq(READ_ETAG), anyString(), any())).thenReturn(CLAIM_ETAG);
+        when(store.claimLease(isNull(), eq(KEY), eq(READ_ETAG), anyString(), any())).thenReturn(CLAIM_ETAG);
 
-        assertEquals(GuardOutcome.EXECUTED, guard.runOnce(KEY, work));
+        assertEquals(GuardOutcome.EXECUTED, guard.runOnce(null, KEY, work));
 
-        verify(work).run(new ClaimToken(KEY, CLAIM_ETAG));
+        verify(work).run(new ClaimToken(null, KEY, CLAIM_ETAG));
     }
 
     @Test
     @DisplayName("Skips when the re-read after a racing insert finds a terminal row")
     void skipsWhenReReadAfterRacingInsertFindsTerminalRow() throws Exception {
-        when(store.readForClaim(KEY))
+        when(store.readForClaim(null, KEY))
                 .thenReturn(null)
                 .thenReturn(new LeaseSnapshot("DONE", READ_ETAG, null, null));
-        when(store.createClaimedRow(eq(KEY), anyString(), any()))
+        when(store.createClaimedRow(isNull(), eq(KEY), anyString(), any()))
                 .thenThrow(new DuplicateRecordException("already exists"));
         when(store.isTerminal("DONE")).thenReturn(true);
 
-        assertEquals(GuardOutcome.SKIPPED_TERMINAL, guard.runOnce(KEY, work));
+        assertEquals(GuardOutcome.SKIPPED_TERMINAL, guard.runOnce(null, KEY, work));
 
         verify(work, never()).run(any());
     }
@@ -198,10 +199,51 @@ class IdempotencyGuardTest {
     @Test
     @DisplayName("Throws LeaseConflictException when the row vanishes between the racing insert and the re-read")
     void throwsLeaseConflictWhenRowVanishesAfterRacingInsert() throws Exception {
-        when(store.readForClaim(KEY)).thenReturn(null).thenReturn(null);
-        when(store.createClaimedRow(eq(KEY), anyString(), any()))
+        when(store.readForClaim(null, KEY)).thenReturn(null).thenReturn(null);
+        when(store.createClaimedRow(isNull(), eq(KEY), anyString(), any()))
                 .thenThrow(new DuplicateRecordException("already exists"));
 
-        assertThrows(LeaseConflictException.class, () -> guard.runOnce(KEY, work));
+        assertThrows(LeaseConflictException.class, () -> guard.runOnce(null, KEY, work));
+    }
+
+    // ---- Client-aware keying ----
+
+    private static final String CLIENT_ID = "9c8b7a65-4d3e-2f1a-0b9c-8d7e6f5a4b3c";
+
+    @Test
+    @DisplayName("Skips a duplicate for an already-terminal row under a client namespace")
+    void skipsWhenTerminalForClient() throws Exception {
+        when(store.readForClaim(CLIENT_ID, KEY)).thenReturn(new LeaseSnapshot("DONE", READ_ETAG, null, null));
+        when(store.isTerminal("DONE")).thenReturn(true);
+
+        assertEquals(GuardOutcome.SKIPPED_TERMINAL, guard.runOnce(CLIENT_ID, KEY, work));
+
+        verify(work, never()).run(any());
+        verify(store, never()).claimLease(any(), anyString(), anyString(), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("Threads the client namespace into the claim token and store calls")
+    void threadsClientNamespaceIntoClaim() throws Exception {
+        when(store.readForClaim(CLIENT_ID, KEY)).thenReturn(new LeaseSnapshot("PENDING", READ_ETAG, null, null));
+        when(store.isTerminal("PENDING")).thenReturn(false);
+        when(store.claimLease(eq(CLIENT_ID), eq(KEY), eq(READ_ETAG), anyString(), any())).thenReturn(CLAIM_ETAG);
+
+        assertEquals(GuardOutcome.EXECUTED, guard.runOnce(CLIENT_ID, KEY, work));
+
+        verify(work).run(new ClaimToken(CLIENT_ID, KEY, CLAIM_ETAG));
+    }
+
+    @Test
+    @DisplayName("A lost claim race under a client namespace still surfaces as LeaseConflictException")
+    void claimRaceLossForClientSurfacesAsLeaseConflict() throws Exception {
+        when(store.readForClaim(CLIENT_ID, KEY)).thenReturn(new LeaseSnapshot("PENDING", READ_ETAG, null, null));
+        when(store.isTerminal("PENDING")).thenReturn(false);
+        when(store.claimLease(eq(CLIENT_ID), eq(KEY), eq(READ_ETAG), anyString(), any()))
+                .thenThrow(new EtagMismatchException("etag changed"));
+
+        assertThrows(LeaseConflictException.class, () -> guard.runOnce(CLIENT_ID, KEY, work));
+
+        verify(work, never()).run(any());
     }
 }

--- a/ai-document-shared-artefacts/src/test/java/uk/gov/moj/cp/ai/service/table/AnswerGenerationTableServiceTest.java
+++ b/ai-document-shared-artefacts/src/test/java/uk/gov/moj/cp/ai/service/table/AnswerGenerationTableServiceTest.java
@@ -34,7 +34,9 @@ import uk.gov.moj.cp.ai.exception.EtagMismatchException;
 import uk.gov.moj.cp.ai.idempotency.IdempotencyStatusStore;
 import uk.gov.moj.cp.ai.idempotency.LeaseSnapshot;
 
+import java.math.BigDecimal;
 import java.time.OffsetDateTime;
+import java.util.List;
 
 import com.azure.data.tables.models.TableEntity;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +64,7 @@ class AnswerGenerationTableServiceTest {
     @Test
     @DisplayName("Successfully saves answer generation request")
     void successfullySavesAnswerGenerationRequest() throws DuplicateRecordException {
-        service.saveAnswerGenerationRequest("tx1", "query", "prompt", ANSWER_GENERATED);
+        service.saveAnswerGenerationRequest(null, "tx1", "query", "prompt", ANSWER_GENERATED);
         verify(tableService).insertIntoTable(any(TableEntity.class));
     }
 
@@ -71,7 +73,7 @@ class AnswerGenerationTableServiceTest {
     void throwsExceptionWhenSaveFailsDueToDuplicateRecord() throws DuplicateRecordException {
         doThrow(new DuplicateRecordException("Insert failed")).when(tableService).insertIntoTable(any(TableEntity.class));
         assertThrows(DuplicateRecordException.class, () ->
-                service.saveAnswerGenerationRequest("tx2", "query", "prompt", ANSWER_GENERATED));
+                service.saveAnswerGenerationRequest(null, "tx2", "query", "prompt", ANSWER_GENERATED));
     }
 
     @Test
@@ -90,7 +92,7 @@ class AnswerGenerationTableServiceTest {
         entity.addProperty(TC_RESPONSE_GENERATION_DURATION, null);
         when(tableService.getFirstDocumentMatching(transactionId, transactionId)).thenReturn(entity);
 
-        GeneratedAnswer answer = service.getGeneratedAnswer(transactionId);
+        GeneratedAnswer answer = service.getGeneratedAnswer(null, transactionId);
         assertNotNull(answer);
         assertEquals(transactionId, answer.getTransactionId());
         assertEquals("query", answer.getUserQuery());
@@ -102,7 +104,7 @@ class AnswerGenerationTableServiceTest {
     @DisplayName("Returns null when no matching entity is found")
     void returnsNullWhenNoMatchingEntityIsFound() throws EntityRetrievalException {
         when(tableService.getFirstDocumentMatching("tx4", "tx4")).thenReturn(null);
-        assertNull(service.getGeneratedAnswer("tx4"));
+        assertNull(service.getGeneratedAnswer(null, "tx4"));
     }
 
     @Test
@@ -110,7 +112,7 @@ class AnswerGenerationTableServiceTest {
     void handlesNullPropertiesGracefullyWhenMappingEntityToGeneratedAnswer() throws EntityRetrievalException {
         TableEntity entity = new TableEntity("tx5", "tx5");
         when(tableService.getFirstDocumentMatching("tx5", "tx5")).thenReturn(entity);
-        GeneratedAnswer answer = service.getGeneratedAnswer("tx5");
+        GeneratedAnswer answer = service.getGeneratedAnswer(null, "tx5");
         assertNotNull(answer);
         assertNull(answer.getTransactionId());
         assertNull(answer.getUserQuery());
@@ -130,7 +132,7 @@ class AnswerGenerationTableServiceTest {
     @Test
     @DisplayName("Fenced terminal write carries the full row and the claim etag")
     void fencedTerminalWriteCarriesFullRowAndClaimEtag() {
-        service.upsertTerminalFenced("tx7", "query", "prompt", "chunks.json", "answer",
+        service.upsertTerminalFenced(null, "tx7", "query", "prompt", "chunks.json", "answer",
                 ANSWER_GENERATED, null, OffsetDateTime.now(), 42L, "W/\"claimed\"");
 
         final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
@@ -153,7 +155,7 @@ class AnswerGenerationTableServiceTest {
         when(entity.getETag()).thenReturn("W/\"read\"");
         when(tableService.getFirstDocumentMatching("tx8", "tx8")).thenReturn(entity);
 
-        final LeaseSnapshot snapshot = service.readForClaim("tx8");
+        final LeaseSnapshot snapshot = service.readForClaim(null, "tx8");
 
         assertEquals(new LeaseSnapshot("ANSWER_GENERATION_PENDING", "W/\"read\"", expiry, "owner-1"), snapshot);
     }
@@ -162,7 +164,7 @@ class AnswerGenerationTableServiceTest {
     @DisplayName("readForClaim returns null when the row is missing")
     void readForClaimReturnsNullWhenRowMissing() throws EntityRetrievalException {
         when(tableService.getFirstDocumentMatching("tx9", "tx9")).thenReturn(null);
-        assertNull(service.readForClaim("tx9"));
+        assertNull(service.readForClaim(null, "tx9"));
     }
 
     @Test
@@ -180,7 +182,7 @@ class AnswerGenerationTableServiceTest {
         final OffsetDateTime expiry = OffsetDateTime.parse("2026-07-14T12:10:00Z");
         when(tableService.updateEntityIfUnchanged(any(TableEntity.class), eq("W/\"read\""))).thenReturn("W/\"claimed\"");
 
-        final String newEtag = service.claimLease("tx10", "W/\"read\"", "owner-1", expiry);
+        final String newEtag = service.claimLease(null, "tx10", "W/\"read\"", "owner-1", expiry);
 
         assertEquals("W/\"claimed\"", newEtag);
         final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
@@ -198,7 +200,7 @@ class AnswerGenerationTableServiceTest {
         final OffsetDateTime expiry = OffsetDateTime.parse("2026-07-14T12:10:00Z");
         when(tableService.insertReturningEtag(any(TableEntity.class))).thenReturn("W/\"created\"");
 
-        final String etag = service.createClaimedRow("tx11", "owner-1", expiry);
+        final String etag = service.createClaimedRow(null, "tx11", "owner-1", expiry);
 
         assertEquals("W/\"created\"", etag);
         final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
@@ -212,7 +214,7 @@ class AnswerGenerationTableServiceTest {
     @Test
     @DisplayName("releaseLease marks the lease reclaimable via the epoch sentinel")
     void releaseLeaseMarksLeaseReclaimable() {
-        service.releaseLease("tx12", "W/\"claimed\"");
+        service.releaseLease(null, "tx12", "W/\"claimed\"");
 
         final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
         verify(tableService).updateEntityIfUnchanged(captor.capture(), eq("W/\"claimed\""));
@@ -225,9 +227,116 @@ class AnswerGenerationTableServiceTest {
         doThrow(new EtagMismatchException("etag changed"))
                 .when(tableService).updateEntityIfUnchanged(any(TableEntity.class), any());
 
-        assertDoesNotThrow(() -> service.releaseLease("tx13", "W/\"stale\""));
+        assertDoesNotThrow(() -> service.releaseLease(null, "tx13", "W/\"stale\""));
 
         verify(tableService).updateEntityIfUnchanged(any(TableEntity.class), eq("W/\"stale\""));
+    }
+
+    // ---- Client-aware partition keying ----
+
+    private static final String CLIENT_A = "11111111-1111-1111-1111-111111111111";
+    private static final String CLIENT_B = "22222222-2222-2222-2222-222222222222";
+
+    @Test
+    @DisplayName("saveAnswerGenerationRequest writes the row under the clientId partition")
+    void saveRequestPartitionsByClientId() throws DuplicateRecordException {
+        service.saveAnswerGenerationRequest(CLIENT_A, "tx", "query", "prompt", ANSWER_GENERATED);
+
+        final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
+        verify(tableService).insertIntoTable(captor.capture());
+        assertEquals(CLIENT_A, captor.getValue().getPartitionKey());
+        assertEquals("tx", captor.getValue().getRowKey());
+    }
+
+    @Test
+    @DisplayName("Two clients sharing one transactionId are stored under distinct partition keys")
+    void twoClientsSharingTransactionIdCoexistUnderDistinctPartitions() throws DuplicateRecordException {
+        service.saveAnswerGenerationRequest(CLIENT_A, "shared-tx", "q", "p", ANSWER_GENERATED);
+        service.saveAnswerGenerationRequest(CLIENT_B, "shared-tx", "q", "p", ANSWER_GENERATED);
+
+        final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
+        verify(tableService, org.mockito.Mockito.times(2)).insertIntoTable(captor.capture());
+        final List<TableEntity> entities = captor.getAllValues();
+        assertEquals(CLIENT_A, entities.get(0).getPartitionKey());
+        assertEquals(CLIENT_B, entities.get(1).getPartitionKey());
+        assertEquals(entities.get(0).getRowKey(), entities.get(1).getRowKey());
+    }
+
+    @Test
+    @DisplayName("getGeneratedAnswer scopes the lookup to the supplied client partition")
+    void getGeneratedAnswerScopesToClientPartition() throws EntityRetrievalException {
+        service.getGeneratedAnswer(CLIENT_A, "tx");
+
+        verify(tableService).getFirstDocumentMatching(CLIENT_A, "tx");
+    }
+
+    @Test
+    @DisplayName("readForClaim scopes the lookup to the supplied client partition")
+    void readForClaimScopesToClientPartition() throws EntityRetrievalException {
+        service.readForClaim(CLIENT_A, "tx");
+
+        verify(tableService).getFirstDocumentMatching(CLIENT_A, "tx");
+    }
+
+    @Test
+    @DisplayName("upsertTerminalFenced writes the fenced terminal row into the supplied client partition")
+    void upsertTerminalFencedPartitionsByClientId() {
+        service.upsertTerminalFenced(CLIENT_A, "tx", "query", "prompt", "chunks.json", "answer",
+                ANSWER_GENERATED, null, OffsetDateTime.now(), 42L, "W/\"claimed\"");
+
+        final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
+        verify(tableService).updateEntityIfUnchanged(captor.capture(), eq("W/\"claimed\""));
+        assertEquals(CLIENT_A, captor.getValue().getPartitionKey());
+    }
+
+    @Test
+    @DisplayName("recordGroundednessScore writes the score into the supplied client partition")
+    void recordGroundednessScorePartitionsByClientId() {
+        service.recordGroundednessScore(CLIENT_A, "tx", new BigDecimal("0.87"));
+
+        final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
+        verify(tableService).upsertIntoTable(captor.capture());
+        assertEquals(CLIENT_A, captor.getValue().getPartitionKey());
+    }
+
+    @Test
+    @DisplayName("claimLease writes the lease into the supplied client partition")
+    void claimLeasePartitionsByClientId() {
+        service.claimLease(CLIENT_A, "tx", "W/\"read\"", "owner-1", OffsetDateTime.parse("2026-07-14T12:10:00Z"));
+
+        final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
+        verify(tableService).updateEntityIfUnchanged(captor.capture(), eq("W/\"read\""));
+        assertEquals(CLIENT_A, captor.getValue().getPartitionKey());
+    }
+
+    @Test
+    @DisplayName("createClaimedRow writes the defensive row into the supplied client partition")
+    void createClaimedRowPartitionsByClientId() throws DuplicateRecordException {
+        service.createClaimedRow(CLIENT_A, "tx", "owner-1", OffsetDateTime.parse("2026-07-14T12:10:00Z"));
+
+        final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
+        verify(tableService).insertReturningEtag(captor.capture());
+        assertEquals(CLIENT_A, captor.getValue().getPartitionKey());
+    }
+
+    @Test
+    @DisplayName("releaseLease marks the reclaimable sentinel in the supplied client partition")
+    void releaseLeasePartitionsByClientId() {
+        service.releaseLease(CLIENT_A, "tx", "W/\"claimed\"");
+
+        final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
+        verify(tableService).updateEntityIfUnchanged(captor.capture(), eq("W/\"claimed\""));
+        assertEquals(CLIENT_A, captor.getValue().getPartitionKey());
+    }
+
+    @Test
+    @DisplayName("A blank clientId falls back to the row key as the partition key")
+    void blankClientIdFallsBackToRowKeyPartition() throws DuplicateRecordException {
+        service.saveAnswerGenerationRequest("", "tx", "query", "prompt", ANSWER_GENERATED);
+
+        final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
+        verify(tableService).insertIntoTable(captor.capture());
+        assertEquals("tx", captor.getValue().getPartitionKey());
     }
 }
 

--- a/ai-document-shared-artefacts/src/test/java/uk/gov/moj/cp/ai/service/table/DocumentIngestionOutcomeTableServiceTest.java
+++ b/ai-document-shared-artefacts/src/test/java/uk/gov/moj/cp/ai/service/table/DocumentIngestionOutcomeTableServiceTest.java
@@ -24,6 +24,7 @@ import uk.gov.moj.cp.ai.idempotency.IdempotencyStatusStore;
 import uk.gov.moj.cp.ai.idempotency.LeaseSnapshot;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 
 import com.azure.data.tables.models.TableEntity;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,7 +58,7 @@ class DocumentIngestionOutcomeTableServiceTest {
     void successfullyInsertsDocumentOutcomeWithDocumentIdAsKey() throws DuplicateRecordException {
         final DocumentIngestionOutcomeTableService service = new DocumentIngestionOutcomeTableService(mockTableService);
 
-        service.insert("docId", "docName", "metadata","doc1,doc2","status", "reason");
+        service.insert(null, "docId", "docName", "metadata","doc1,doc2","status", "reason");
 
         final ArgumentCaptor<TableEntity> tableEntityCaptor = ArgumentCaptor.forClass(TableEntity.class);
         verify(mockTableService).insertIntoTable(tableEntityCaptor.capture());
@@ -80,7 +81,7 @@ class DocumentIngestionOutcomeTableServiceTest {
         final TableEntity mockTableEntity = mock(TableEntity.class);
         when(mockTableService.getFirstDocumentMatching("docId", "docId")).thenReturn(mockTableEntity);
 
-        final DocumentIngestionOutcome document = service.getDocumentById("docId");
+        final DocumentIngestionOutcome document = service.getDocumentById(null, "docId");
 
         verify(mockTableService).getFirstDocumentMatching("docId", "docId");
     }
@@ -97,7 +98,7 @@ class DocumentIngestionOutcomeTableServiceTest {
                 .addProperty("Reason", "reason");
         when(mockTableService.getFirstDocumentMatching(docId, docId)).thenReturn(entity);
 
-        service.upsertDocument(docId, "status", "reason");
+        service.upsertDocument(null, docId, "status", "reason");
 
         verify(mockTableService).upsertIntoTable(any(TableEntity.class));
     }
@@ -109,7 +110,7 @@ class DocumentIngestionOutcomeTableServiceTest {
     void recordOutcomeFencedMergesOnlyStatusAndReason() {
         final DocumentIngestionOutcomeTableService service = new DocumentIngestionOutcomeTableService(mockTableService);
 
-        service.recordOutcomeFenced("docId", "INGESTION_SUCCESS", "done", "W/\"claimed\"");
+        service.recordOutcomeFenced(null, "docId", "INGESTION_SUCCESS", "done", "W/\"claimed\"");
 
         final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
         verify(mockTableService).updateEntityIfUnchanged(captor.capture(), org.mockito.ArgumentMatchers.eq("W/\"claimed\""));
@@ -136,7 +137,7 @@ class DocumentIngestionOutcomeTableServiceTest {
         when(mockTableService.getFirstDocumentMatching("docId", "docId")).thenReturn(entity);
 
         assertEquals(new LeaseSnapshot("AWAITING_INGESTION", "W/\"read\"", expiry, "owner-1"),
-                service.readForClaim("docId"));
+                service.readForClaim(null, "docId"));
     }
 
     @Test
@@ -159,7 +160,7 @@ class DocumentIngestionOutcomeTableServiceTest {
         when(mockTableService.updateEntityIfUnchanged(any(TableEntity.class), org.mockito.ArgumentMatchers.eq("W/\"read\"")))
                 .thenReturn("W/\"claimed\"");
 
-        assertEquals("W/\"claimed\"", service.claimLease("docId", "W/\"read\"", "owner-1", expiry));
+        assertEquals("W/\"claimed\"", service.claimLease(null, "docId", "W/\"read\"", "owner-1", expiry));
 
         final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
         verify(mockTableService).updateEntityIfUnchanged(captor.capture(), org.mockito.ArgumentMatchers.eq("W/\"read\""));
@@ -176,7 +177,7 @@ class DocumentIngestionOutcomeTableServiceTest {
         final OffsetDateTime expiry = OffsetDateTime.parse("2026-07-14T12:10:00Z");
         when(mockTableService.insertReturningEtag(any(TableEntity.class))).thenReturn("W/\"created\"");
 
-        assertEquals("W/\"created\"", service.createClaimedRow("docId", "owner-1", expiry));
+        assertEquals("W/\"created\"", service.createClaimedRow(null, "docId", "owner-1", expiry));
 
         final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
         verify(mockTableService).insertReturningEtag(captor.capture());
@@ -191,7 +192,7 @@ class DocumentIngestionOutcomeTableServiceTest {
     void releaseLeaseMarksLeaseReclaimableAndSwallowsRejection() {
         final DocumentIngestionOutcomeTableService service = new DocumentIngestionOutcomeTableService(mockTableService);
 
-        service.releaseLease("docId", "W/\"claimed\"");
+        service.releaseLease(null, "docId", "W/\"claimed\"");
 
         final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
         verify(mockTableService).updateEntityIfUnchanged(captor.capture(), org.mockito.ArgumentMatchers.eq("W/\"claimed\""));
@@ -200,6 +201,121 @@ class DocumentIngestionOutcomeTableServiceTest {
         // best-effort: a rejected release must not throw
         org.mockito.Mockito.doThrow(new EtagMismatchException("etag changed"))
                 .when(mockTableService).updateEntityIfUnchanged(any(TableEntity.class), org.mockito.ArgumentMatchers.eq("W/\"stale\""));
-        service.releaseLease("docId", "W/\"stale\"");
+        service.releaseLease(null, "docId", "W/\"stale\"");
+    }
+
+    // ---- Client-aware partition keying ----
+
+    private static final String CLIENT_A = "11111111-1111-1111-1111-111111111111";
+    private static final String CLIENT_B = "22222222-2222-2222-2222-222222222222";
+
+    @Test
+    @DisplayName("insert writes the row under the clientId partition when a clientId is supplied")
+    void insertPartitionsByClientId() throws DuplicateRecordException {
+        final DocumentIngestionOutcomeTableService service = new DocumentIngestionOutcomeTableService(mockTableService);
+
+        service.insert(CLIENT_A, "docId", "docName", "metadata", "", "status", "reason");
+
+        final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
+        verify(mockTableService).insertIntoTable(captor.capture());
+        assertEquals(CLIENT_A, captor.getValue().getPartitionKey());
+        assertEquals("docId", captor.getValue().getRowKey());
+    }
+
+    @Test
+    @DisplayName("Two clients sharing one documentId are stored under distinct partition keys")
+    void twoClientsSharingDocumentIdCoexistUnderDistinctPartitions() throws DuplicateRecordException {
+        final DocumentIngestionOutcomeTableService service = new DocumentIngestionOutcomeTableService(mockTableService);
+
+        service.insert(CLIENT_A, "shared-doc", "n", "m", "", "s", "r");
+        service.insert(CLIENT_B, "shared-doc", "n", "m", "", "s", "r");
+
+        final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
+        verify(mockTableService, org.mockito.Mockito.times(2)).insertIntoTable(captor.capture());
+        final List<TableEntity> entities = captor.getAllValues();
+        assertEquals(CLIENT_A, entities.get(0).getPartitionKey());
+        assertEquals(CLIENT_B, entities.get(1).getPartitionKey());
+        assertEquals(entities.get(0).getRowKey(), entities.get(1).getRowKey());
+    }
+
+    @Test
+    @DisplayName("getDocumentById scopes the lookup to the supplied client partition")
+    void getDocumentByIdScopesToClientPartition() throws EntityRetrievalException {
+        final DocumentIngestionOutcomeTableService service = new DocumentIngestionOutcomeTableService(mockTableService);
+
+        service.getDocumentById(CLIENT_A, "docId");
+
+        verify(mockTableService).getFirstDocumentMatching(CLIENT_A, "docId");
+    }
+
+    @Test
+    @DisplayName("readForClaim scopes the lookup to the supplied client partition")
+    void readForClaimScopesToClientPartition() throws EntityRetrievalException {
+        final DocumentIngestionOutcomeTableService service = new DocumentIngestionOutcomeTableService(mockTableService);
+
+        service.readForClaim(CLIENT_A, "docId");
+
+        verify(mockTableService).getFirstDocumentMatching(CLIENT_A, "docId");
+    }
+
+    @Test
+    @DisplayName("claimLease writes the lease into the supplied client partition")
+    void claimLeasePartitionsByClientId() {
+        final DocumentIngestionOutcomeTableService service = new DocumentIngestionOutcomeTableService(mockTableService);
+
+        service.claimLease(CLIENT_A, "docId", "W/\"read\"", "owner-1", OffsetDateTime.parse("2026-07-14T12:10:00Z"));
+
+        final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
+        verify(mockTableService).updateEntityIfUnchanged(captor.capture(), org.mockito.ArgumentMatchers.eq("W/\"read\""));
+        assertEquals(CLIENT_A, captor.getValue().getPartitionKey());
+    }
+
+    @Test
+    @DisplayName("createClaimedRow writes the defensive row into the supplied client partition")
+    void createClaimedRowPartitionsByClientId() throws DuplicateRecordException {
+        final DocumentIngestionOutcomeTableService service = new DocumentIngestionOutcomeTableService(mockTableService);
+
+        service.createClaimedRow(CLIENT_A, "docId", "owner-1", OffsetDateTime.parse("2026-07-14T12:10:00Z"));
+
+        final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
+        verify(mockTableService).insertReturningEtag(captor.capture());
+        assertEquals(CLIENT_A, captor.getValue().getPartitionKey());
+    }
+
+    @Test
+    @DisplayName("recordOutcomeFenced writes the fenced outcome into the supplied client partition")
+    void recordOutcomeFencedPartitionsByClientId() {
+        final DocumentIngestionOutcomeTableService service = new DocumentIngestionOutcomeTableService(mockTableService);
+
+        service.recordOutcomeFenced(CLIENT_A, "docId", "INGESTION_SUCCESS", "done", "W/\"claimed\"");
+
+        final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
+        verify(mockTableService).updateEntityIfUnchanged(captor.capture(), org.mockito.ArgumentMatchers.eq("W/\"claimed\""));
+        assertEquals(CLIENT_A, captor.getValue().getPartitionKey());
+    }
+
+    @Test
+    @DisplayName("releaseLease marks the reclaimable sentinel in the supplied client partition")
+    void releaseLeasePartitionsByClientId() {
+        final DocumentIngestionOutcomeTableService service = new DocumentIngestionOutcomeTableService(mockTableService);
+
+        service.releaseLease(CLIENT_A, "docId", "W/\"claimed\"");
+
+        final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
+        verify(mockTableService).updateEntityIfUnchanged(captor.capture(), org.mockito.ArgumentMatchers.eq("W/\"claimed\""));
+        assertEquals(CLIENT_A, captor.getValue().getPartitionKey());
+        assertEquals(IdempotencyStatusStore.LEASE_RELEASED, captor.getValue().getProperty(TC_LEASE_EXPIRES_AT));
+    }
+
+    @Test
+    @DisplayName("A blank clientId falls back to the row key as the partition key")
+    void blankClientIdFallsBackToRowKeyPartition() throws DuplicateRecordException {
+        final DocumentIngestionOutcomeTableService service = new DocumentIngestionOutcomeTableService(mockTableService);
+
+        service.insert("", "docId", "docName", "metadata", "", "status", "reason");
+
+        final ArgumentCaptor<TableEntity> captor = ArgumentCaptor.forClass(TableEntity.class);
+        verify(mockTableService).insertIntoTable(captor.capture());
+        assertEquals("docId", captor.getValue().getPartitionKey());
     }
 }

--- a/ai-document-status-check-function/src/main/java/uk/gov/moj/cp/azure/status/check/DocumentStatusByReferenceFunction.java
+++ b/ai-document-status-check-function/src/main/java/uk/gov/moj/cp/azure/status/check/DocumentStatusByReferenceFunction.java
@@ -67,7 +67,7 @@ public class DocumentStatusByReferenceFunction {
                 return generateResponse(request, HttpStatus.BAD_REQUEST, convert(new RequestErrored(errorMessage)));
             }
 
-            final DocumentIngestionOutcome document = documentIngestionOutcomeTableService.getDocumentById(documentReference);
+            final DocumentIngestionOutcome document = documentIngestionOutcomeTableService.getDocumentById(null, documentReference);
 
             if (isNull(document)) {
                 return generateResponse(request, NOT_FOUND, convert(new RequestErrored(format("No Document found for the documentReference=%s", documentReference))));

--- a/ai-document-status-check-function/src/test/java/uk/gov/moj/cp/azure/status/check/DocumentStatusByReferenceFunctionTest.java
+++ b/ai-document-status-check-function/src/test/java/uk/gov/moj/cp/azure/status/check/DocumentStatusByReferenceFunctionTest.java
@@ -66,11 +66,11 @@ class DocumentStatusByReferenceFunctionTest {
         when(outcome.getStatus()).thenReturn("INGESTION_SUCCESS");
         when(outcome.getTimestamp()).thenReturn("2024-01-01T10:00:00Z");
         when(outcome.getReason()).thenReturn("success");
-        when(documentIngestionOutcomeTableService.getDocumentById(documentId)).thenReturn(outcome);
+        when(documentIngestionOutcomeTableService.getDocumentById(null, documentId)).thenReturn(outcome);
 
         final HttpResponseMessage result = function.run(request, documentId, context);
 
-        verify(documentIngestionOutcomeTableService).getDocumentById(documentId);
+        verify(documentIngestionOutcomeTableService).getDocumentById(null, documentId);
         verify(request).createResponseBuilder(HttpStatus.OK);
         assertEquals(response, result);
     }
@@ -91,7 +91,7 @@ class DocumentStatusByReferenceFunctionTest {
     void shouldReturnNotFoundWhenNoDocumentInTheDBForTheDocumentReference() throws EntityRetrievalException {
 
         final String documentId = randomUUID().toString();
-        when(documentIngestionOutcomeTableService.getDocumentById(documentId)).thenReturn(null);
+        when(documentIngestionOutcomeTableService.getDocumentById(null, documentId)).thenReturn(null);
 
         final HttpResponseMessage result = function.run(request, documentId, context);
 
@@ -102,7 +102,7 @@ class DocumentStatusByReferenceFunctionTest {
     @Test
     void shouldReturnInternalServerErrorWhenServiceThrowsException() throws EntityRetrievalException {
         final String documentId = randomUUID().toString();
-        when(documentIngestionOutcomeTableService.getDocumentById(documentId)).thenThrow(new RuntimeException("Service failure"));
+        when(documentIngestionOutcomeTableService.getDocumentById(null, documentId)).thenThrow(new RuntimeException("Service failure"));
 
         final HttpResponseMessage result = function.run(request, documentId, context);
 


### PR DESCRIPTION
**Jira:** DD-42978 (sub-task of DD-42722)

Story MTDI03 (Phase 1 — client-aware storage) of the multi-client data isolation initiative. **Merge-safe with zero behaviour change today:** every production call site passes a null clientId, which keeps the legacy PartitionKey == RowKey keying byte-for-byte; a real clientId only starts flowing when the HTTP/worker wiring story lands.

## What's in this PR
- `IdempotencyStatusStore`, `IdempotencyGuard` (`runOnce(clientId, key, work)`) and `ClaimToken` (`(clientId, key, etag)`) become client-aware across the lease claim/release/fence surface.
- Both status table services (`DocumentIngestionOutcomeTableService`, `AnswerGenerationTableService`) key rows by `(clientId, id)`: effective partition key is the clientId when supplied, falling back to the row key when absent. All 16 entity-construction/lookup sites route through a single seam per service.
- `DocumentUploadService` dedup lookup becomes client-scoped; all function call sites (upload, ingestion, retrieval, scoring, status) mechanically migrated passing null.
- Lease semantics untouched beyond the key: ETag/If-Match fencing, 412 handling, LEASE_RELEASED sentinel, terminal-status skip, live-lease behaviour at redelivery exhaustion.

## Test evidence
- A-TDD: 17 partition-scoping tests scaffolded red first (failing `expected: <clientId> but was: <key>`), turned green by the seam flip; legacy null/blank-fallback locks green throughout.
- `ai-document-shared-artefacts`: 236 tests, 0 failures. All six dependent modules re-run green (metadata-check, ingestion, answer-retrieval 153, scoring 23, status-check 4, migration-tool 54).
- Structured code review in progress; any findings will be addressed as follow-up commits on this PR.

## Design & stories
`docs/pipeline/DD-42722-multi-tenant-data-isolation/` — [design](https://github.com/hmcts/cp-ai-rag-service/blob/main/docs/pipeline/DD-42722-multi-tenant-data-isolation/02-design.md) §C, [stories](https://github.com/hmcts/cp-ai-rag-service/blob/main/docs/pipeline/DD-42722-multi-tenant-data-isolation/03-stories.md) §MTDI03.

Note: will be rebased if/when PR 116 (migration tool, disjoint modules) merges first.