### PR TITLE
feat: client-prefixed blob paths with dual-path legacy resolution

### DIFF
--- a/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/AnswerGenerationFunction.java
+++ b/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/AnswerGenerationFunction.java
@@ -419,7 +419,7 @@ public class AnswerGenerationFunction {
 
     private String saveLlmResponseToTheBlobContainer(final UUID transactionId, final String userQuery, final String queryPrompt,
                                                      final String llmResponse, final List<ChunkedEntry> chunkedEntries) throws JsonProcessingException {
-        final String filename = getAnswerWithChunksFilename(transactionId);
+        final String filename = getAnswerWithChunksFilename(null, transactionId);
         final ScoringPayload scoringPayload = new ScoringPayload(userQuery,
                 llmResponse, queryPrompt, chunkedEntries, transactionId.toString());
         blobPersistenceEvalPayloadsService.saveBlob(filename, convert(scoringPayload));
@@ -427,7 +427,7 @@ public class AnswerGenerationFunction {
     }
 
     private String saveInputChunksToTheBlobContainer(final UUID transactionId, final List<ChunkedEntry> chunkedEntries) throws JsonProcessingException {
-        final String inputChunksFilename = getInputChunksFilename(transactionId);
+        final String inputChunksFilename = getInputChunksFilename(null, transactionId);
         final InputChunksPayload inputChunksPayload = new InputChunksPayload(chunkedEntries);
 
         blobPersistenceInputChunksService.saveBlob(inputChunksFilename, convert(inputChunksPayload));

--- a/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/GetAnswerGenerationResultFunction.java
+++ b/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/GetAnswerGenerationResultFunction.java
@@ -91,7 +91,7 @@ public class GetAnswerGenerationResultFunction {
                 final boolean withChunkedEntries = parseBoolean(request.getQueryParameters().getOrDefault(PARAM_WITH_CHUNKED_ENTRIES, "false"));
                 final List<ChunkedEntry> chunkedEntriesFromBlobContainer =
                         (withChunkedEntries && !isNullOrEmpty(generatedAnswer.getChunkedEntriesFile()))
-                                ? blobPersistenceInputChunksService.readBlob(getInputChunksFilename(fromString(transactionId)), InputChunksPayload.class).chunkedEntries()
+                                ? blobPersistenceInputChunksService.readBlob(getInputChunksFilename(null, fromString(transactionId)), InputChunksPayload.class).chunkedEntries()
                                 : null;
 
                 return generateResponse(request, OK, convert(toQueryResponse(generatedAnswer, chunkedEntriesFromBlobContainer)));

--- a/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/SyncAnswerGenerationFunction.java
+++ b/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/SyncAnswerGenerationFunction.java
@@ -142,7 +142,7 @@ public class SyncAnswerGenerationFunction {
                 return generateResponse(request, OK, responseAsString);
             }
 
-            final String filename = getAnswerWithChunksFilename(randomUUID());
+            final String filename = getAnswerWithChunksFilename(null, randomUUID());
             final ScoringPayload scoringPayload = new ScoringPayload(
                     userQuery, llmResponse.formattedLlmResponse(), userQueryPrompt, chunkedEntries, null);
             blobPersistenceService.saveBlob(filename, convert(scoringPayload));

--- a/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/util/ChunkUtil.java
+++ b/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/util/ChunkUtil.java
@@ -31,7 +31,8 @@ public class ChunkUtil {
 
     /**
      * Client-scoped variant of {@link #getInputChunksFilename(UUID)}. Prepends the client prefix when
-     * a clientId is supplied; falls back to the unprefixed name otherwise. Prefixing is not yet built.
+     * a clientId is supplied; falls back to the unprefixed name otherwise (callers currently pass null
+     * until the HTTP functions resolve a real client identity).
      */
     public static String getInputChunksFilename(final String clientId, final UUID transactionId) {
         final String flat = getInputChunksFilename(transactionId);
@@ -40,12 +41,14 @@ public class ChunkUtil {
 
     /**
      * Client-scoped variant of {@link #getAnswerWithChunksFilename(UUID)}. Prepends the client prefix
-     * when a clientId is supplied; falls back to the unprefixed name otherwise. Prefixing is not yet built.
+     * when a clientId is supplied; falls back to the unprefixed name otherwise (callers currently pass
+     * null until the HTTP functions resolve a real client identity).
      */
     public static String getAnswerWithChunksFilename(final String clientId, final UUID id) {
         final String flat = getAnswerWithChunksFilename(id);
         return isNullOrEmpty(clientId) ? flat : format("c=%s/%s", clientId, flat);
     }
+
     public static List<DocumentChunk> transformChunkEntries(final List<ChunkedEntry> chunkedEntries) {
         if (null == chunkedEntries || chunkedEntries.isEmpty()) {
             return Collections.emptyList();

--- a/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/util/ChunkUtil.java
+++ b/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/util/ChunkUtil.java
@@ -1,6 +1,7 @@
 package uk.gov.moj.cp.retrieval.util;
 
 import static java.lang.String.format;
+import static uk.gov.moj.cp.ai.util.StringUtil.isNullOrEmpty;
 
 import uk.gov.hmcts.cp.openapi.model.DocumentChunk;
 import uk.gov.hmcts.cp.openapi.model.MetadataFilter;
@@ -33,8 +34,8 @@ public class ChunkUtil {
      * a clientId is supplied; falls back to the unprefixed name otherwise. Prefixing is not yet built.
      */
     public static String getInputChunksFilename(final String clientId, final UUID transactionId) {
-        // TODO: prepend the c={clientId}/ prefix when clientId is non-empty
-        return getInputChunksFilename(transactionId);
+        final String flat = getInputChunksFilename(transactionId);
+        return isNullOrEmpty(clientId) ? flat : format("c=%s/%s", clientId, flat);
     }
 
     /**
@@ -42,8 +43,8 @@ public class ChunkUtil {
      * when a clientId is supplied; falls back to the unprefixed name otherwise. Prefixing is not yet built.
      */
     public static String getAnswerWithChunksFilename(final String clientId, final UUID id) {
-        // TODO: prepend the c={clientId}/ prefix when clientId is non-empty
-        return getAnswerWithChunksFilename(id);
+        final String flat = getAnswerWithChunksFilename(id);
+        return isNullOrEmpty(clientId) ? flat : format("c=%s/%s", clientId, flat);
     }
     public static List<DocumentChunk> transformChunkEntries(final List<ChunkedEntry> chunkedEntries) {
         if (null == chunkedEntries || chunkedEntries.isEmpty()) {

--- a/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/util/ChunkUtil.java
+++ b/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/util/ChunkUtil.java
@@ -1,7 +1,7 @@
 package uk.gov.moj.cp.retrieval.util;
 
 import static java.lang.String.format;
-import static uk.gov.moj.cp.ai.util.StringUtil.isNullOrEmpty;
+import static uk.gov.moj.cp.ai.storage.BlobNamespace.applyClientPrefix;
 
 import uk.gov.hmcts.cp.openapi.model.DocumentChunk;
 import uk.gov.hmcts.cp.openapi.model.MetadataFilter;
@@ -35,8 +35,7 @@ public class ChunkUtil {
      * until the HTTP functions resolve a real client identity).
      */
     public static String getInputChunksFilename(final String clientId, final UUID transactionId) {
-        final String flat = getInputChunksFilename(transactionId);
-        return isNullOrEmpty(clientId) ? flat : format("c=%s/%s", clientId, flat);
+        return applyClientPrefix(clientId, getInputChunksFilename(transactionId));
     }
 
     /**
@@ -45,8 +44,7 @@ public class ChunkUtil {
      * null until the HTTP functions resolve a real client identity).
      */
     public static String getAnswerWithChunksFilename(final String clientId, final UUID id) {
-        final String flat = getAnswerWithChunksFilename(id);
-        return isNullOrEmpty(clientId) ? flat : format("c=%s/%s", clientId, flat);
+        return applyClientPrefix(clientId, getAnswerWithChunksFilename(id));
     }
 
     public static List<DocumentChunk> transformChunkEntries(final List<ChunkedEntry> chunkedEntries) {

--- a/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/util/ChunkUtil.java
+++ b/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/util/ChunkUtil.java
@@ -27,6 +27,24 @@ public class ChunkUtil {
     public static String getAnswerWithChunksFilename(final UUID id) {
         return format(LLM_ANSWER_WITH_CHUNKS, id);
     }
+
+    /**
+     * Client-scoped variant of {@link #getInputChunksFilename(UUID)}. Prepends the client prefix when
+     * a clientId is supplied; falls back to the unprefixed name otherwise. Prefixing is not yet built.
+     */
+    public static String getInputChunksFilename(final String clientId, final UUID transactionId) {
+        // TODO: prepend the c={clientId}/ prefix when clientId is non-empty
+        return getInputChunksFilename(transactionId);
+    }
+
+    /**
+     * Client-scoped variant of {@link #getAnswerWithChunksFilename(UUID)}. Prepends the client prefix
+     * when a clientId is supplied; falls back to the unprefixed name otherwise. Prefixing is not yet built.
+     */
+    public static String getAnswerWithChunksFilename(final String clientId, final UUID id) {
+        // TODO: prepend the c={clientId}/ prefix when clientId is non-empty
+        return getAnswerWithChunksFilename(id);
+    }
     public static List<DocumentChunk> transformChunkEntries(final List<ChunkedEntry> chunkedEntries) {
         if (null == chunkedEntries || chunkedEntries.isEmpty()) {
             return Collections.emptyList();

--- a/ai-document-answer-retrieval-function/src/test/java/uk/gov/moj/cp/retrieval/util/ChunkUtilTest.java
+++ b/ai-document-answer-retrieval-function/src/test/java/uk/gov/moj/cp/retrieval/util/ChunkUtilTest.java
@@ -2,6 +2,8 @@ package uk.gov.moj.cp.retrieval.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.moj.cp.retrieval.util.ChunkUtil.getAnswerWithChunksFilename;
+import static uk.gov.moj.cp.retrieval.util.ChunkUtil.getInputChunksFilename;
 import static uk.gov.moj.cp.retrieval.util.ChunkUtil.transformChunkEntries;
 
 import uk.gov.hmcts.cp.openapi.model.DocumentChunk;
@@ -11,6 +13,7 @@ import uk.gov.moj.cp.ai.model.KeyValuePair;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -60,6 +63,46 @@ class ChunkUtilTest {
         assertEquals("value1", chunk.getCustomMetadata().getFirst().getValue());
     }
 
+
+    @Test
+    @DisplayName("Prefixes input-chunks filename when clientId present")
+    void prefixesInputChunksFilenameWhenClientIdPresent() {
+        final UUID transactionId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+        final String filename = getInputChunksFilename("client-1", transactionId);
+
+        assertEquals("c=client-1/llm-input-chunks-00000000-0000-0000-0000-000000000001.json", filename);
+    }
+
+    @Test
+    @DisplayName("Leaves input-chunks filename unchanged when clientId is null")
+    void leavesInputChunksFilenameUnchangedWhenClientIdIsNull() {
+        final UUID transactionId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+        final String filename = getInputChunksFilename(null, transactionId);
+
+        assertEquals("llm-input-chunks-00000000-0000-0000-0000-000000000001.json", filename);
+    }
+
+    @Test
+    @DisplayName("Prefixes answer-with-chunks filename when clientId present")
+    void prefixesAnswerWithChunksFilenameWhenClientIdPresent() {
+        final UUID transactionId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+
+        final String filename = getAnswerWithChunksFilename("client-1", transactionId);
+
+        assertEquals("c=client-1/llm-answer-with-chunks-00000000-0000-0000-0000-000000000002.json", filename);
+    }
+
+    @Test
+    @DisplayName("Leaves answer-with-chunks filename unchanged when clientId is null")
+    void leavesAnswerWithChunksFilenameUnchangedWhenClientIdIsNull() {
+        final UUID transactionId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+
+        final String filename = getAnswerWithChunksFilename(null, transactionId);
+
+        assertEquals("llm-answer-with-chunks-00000000-0000-0000-0000-000000000002.json", filename);
+    }
 
     private List<ChunkedEntry> createChunkedEntries(int count) {
         List<ChunkedEntry> entries = new ArrayList<>();

--- a/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/DocumentBlobTriggerFunction.java
+++ b/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/DocumentBlobTriggerFunction.java
@@ -79,7 +79,7 @@ public class DocumentBlobTriggerFunction {
 
             final String documentId = documentBlobNameResolver.getDocumentId(blobName);
             final String clientId = documentBlobNameResolver.getClientId(blobName);
-            final DocumentIngestionOutcome document = documentUploadService.getDocument(documentId);
+            final DocumentIngestionOutcome document = documentUploadService.getDocument(clientId, documentId);
 
             final long blobSize = blobClientService.getBlobClient(blobName).getProperties().getBlobSize();
             LOGGER.info("Document blob size={} for blobName:{}", blobSize, blobName);

--- a/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/DocumentBlobTriggerFunction.java
+++ b/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/DocumentBlobTriggerFunction.java
@@ -78,6 +78,7 @@ public class DocumentBlobTriggerFunction {
             }
 
             final String documentId = documentBlobNameResolver.getDocumentId(blobName);
+            final String clientId = documentBlobNameResolver.getClientId(blobName);
             final DocumentIngestionOutcome document = documentUploadService.getDocument(documentId);
 
             final long blobSize = blobClientService.getBlobClient(blobName).getProperties().getBlobSize();
@@ -91,7 +92,7 @@ public class DocumentBlobTriggerFunction {
             }
 
             final Map<String, String> metadataMap = stringToMap(document.getMetadata());
-            final QueueIngestionMetadata queueIngestionMetadata = createQueueMessage(blobName, document.getDocumentName(), flatten(documentId, metadataMap));
+            final QueueIngestionMetadata queueIngestionMetadata = createQueueMessage(blobName, document.getDocumentName(), flatten(documentId, metadataMap), clientId);
             queueMessage.setValue(convert(queueIngestionMetadata));
 
             LOGGER.info("Document blob trigger function processed a request for document with blobName: {}", blobName);
@@ -100,14 +101,14 @@ public class DocumentBlobTriggerFunction {
         }
     }
 
-    private QueueIngestionMetadata createQueueMessage(final String blobName, final String documentName, final Map<String, String> metadata) {
+    private QueueIngestionMetadata createQueueMessage(final String blobName, final String documentName, final Map<String, String> metadata, final String clientId) {
         final String documentId = metadata.get(DOCUMENT_ID_NEW);
         final String blobStorageEndpoint = removeTrailingSlash(getRequiredEnv(AI_RAG_SERVICE_BLOB_STORAGE_ENDPOINT));
         final String containerName = getRequiredEnv(STORAGE_ACCOUNT_BLOB_CONTAINER_NAME_DOCUMENT_UPLOAD);
         final String blobUrl = format("%s/%s/%s", blobStorageEndpoint, containerName, blobName);
         final String currentTimestamp = Instant.now().toString();
 
-        return new QueueIngestionMetadata(documentId, documentName, metadata, blobUrl, currentTimestamp);
+        return new QueueIngestionMetadata(documentId, documentName, metadata, blobUrl, currentTimestamp, clientId);
     }
 
     private static Map<String, String> flatten(final String documentId, final Map<String, String> metadataMap) {

--- a/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/utils/DocumentBlobNameResolver.java
+++ b/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/utils/DocumentBlobNameResolver.java
@@ -2,6 +2,8 @@ package uk.gov.moj.cp.metadata.check.utils;
 
 import static java.lang.String.format;
 import static java.time.format.DateTimeFormatter.ofPattern;
+import static uk.gov.moj.cp.ai.storage.BlobNamespace.CLIENT_PREFIX_MARKER;
+import static uk.gov.moj.cp.ai.storage.BlobNamespace.applyClientPrefix;
 import static uk.gov.moj.cp.ai.util.EnvVarUtil.getRequiredEnv;
 import static uk.gov.moj.cp.ai.util.StringUtil.isNullOrEmpty;
 import static uk.gov.moj.cp.metadata.check.service.DocumentMetadataVariables.UPLOAD_FILE_DATE_FORMAT;
@@ -14,8 +16,8 @@ import java.util.regex.Pattern;
 public class DocumentBlobNameResolver {
 
     private static final Pattern BLOB_PATTERN = Pattern.compile("^([^_]+)_([0-9]{8})\\.[^.]+$");
-    private static final Pattern PREFIXED_BLOB_PATTERN = Pattern.compile("^c=([^/]+)/([^/_]+)_([0-9]{8})\\.[^.]+$");
-    private static final String CLIENT_PREFIX_MARKER = "c=";
+    private static final Pattern PREFIXED_BLOB_PATTERN =
+            Pattern.compile("^" + Pattern.quote(CLIENT_PREFIX_MARKER) + "([^/]+)/([^/_]+)_([0-9]{8})\\.[^.]+$");
     private static final String INVALID_BLOB_NAME_ERROR_MSG = "Invalid blobName: '%s' format, expected format is documentId_yyyyMMdd.fileExtension";
     private static final String DEFAULT_DATETIME_FORMAT = "yyyyMMdd";
 
@@ -36,8 +38,7 @@ public class DocumentBlobNameResolver {
      * a null/empty clientId yields the flat shape.
      */
     public String getBlobName(final String clientId, final String documentId, final String uploadFileExtension) {
-        final String flat = getBlobName(documentId, uploadFileExtension);
-        return isNullOrEmpty(clientId) ? flat : format("c=%s/%s", clientId, flat);
+        return applyClientPrefix(clientId, getBlobName(documentId, uploadFileExtension));
     }
 
     public String getDocumentId(final String blobName) {

--- a/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/utils/DocumentBlobNameResolver.java
+++ b/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/utils/DocumentBlobNameResolver.java
@@ -28,6 +28,15 @@ public class DocumentBlobNameResolver {
         return format("%s_%s.%s", documentId, today, uploadFileExtension);
     }
 
+    /**
+     * Builds a client-namespaced blob name when a clientId is supplied, falling back to the flat
+     * shape otherwise. The prefixed shape is not yet produced.
+     */
+    public String getBlobName(final String clientId, final String documentId, final String uploadFileExtension) {
+        // TODO: prepend the c={clientId}/ prefix when clientId is non-empty
+        return getBlobName(documentId, uploadFileExtension);
+    }
+
     public String getDocumentId(final String blobName) {
         if (isNullOrEmpty(blobName)) {
             throw new IllegalArgumentException(format(INVALID_BLOB_NAME_ERROR_MSG, blobName));
@@ -39,5 +48,14 @@ public class DocumentBlobNameResolver {
         }
 
         return matcher.group(1);
+    }
+
+    /**
+     * Returns the clientId encoded in a namespaced blob name, or {@code null} when the name has no
+     * prefix (defer to the Table row for ownership). Prefix extraction is not yet implemented.
+     */
+    public String getClientId(final String blobName) {
+        // TODO: extract the clientId from the c={clientId}/ prefix when present
+        return null;
     }
 }

--- a/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/utils/DocumentBlobNameResolver.java
+++ b/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/utils/DocumentBlobNameResolver.java
@@ -14,6 +14,7 @@ import java.util.regex.Pattern;
 public class DocumentBlobNameResolver {
 
     private static final Pattern BLOB_PATTERN = Pattern.compile("^([^_]+)_([0-9]{8})\\.[^.]+$");
+    private static final Pattern PREFIXED_BLOB_PATTERN = Pattern.compile("^c=([^/]+)/([^_]+)_([0-9]{8})\\.[^.]+$");
     private static final String INVALID_BLOB_NAME_ERROR_MSG = "Invalid blobName: '%s' format, expected format is documentId_yyyyMMdd.fileExtension";
     private static final String DEFAULT_DATETIME_FORMAT = "yyyyMMdd";
 
@@ -30,16 +31,22 @@ public class DocumentBlobNameResolver {
 
     /**
      * Builds a client-namespaced blob name when a clientId is supplied, falling back to the flat
-     * shape otherwise. The prefixed shape is not yet produced.
+     * shape otherwise. A non-empty clientId yields {@code c={clientId}/{documentId}_{yyyyMMdd}.{ext}};
+     * a null/empty clientId yields the flat shape.
      */
     public String getBlobName(final String clientId, final String documentId, final String uploadFileExtension) {
-        // TODO: prepend the c={clientId}/ prefix when clientId is non-empty
-        return getBlobName(documentId, uploadFileExtension);
+        final String flat = getBlobName(documentId, uploadFileExtension);
+        return isNullOrEmpty(clientId) ? flat : format("c=%s/%s", clientId, flat);
     }
 
     public String getDocumentId(final String blobName) {
         if (isNullOrEmpty(blobName)) {
             throw new IllegalArgumentException(format(INVALID_BLOB_NAME_ERROR_MSG, blobName));
+        }
+
+        final Matcher prefixedMatcher = PREFIXED_BLOB_PATTERN.matcher(blobName);
+        if (prefixedMatcher.matches()) {
+            return prefixedMatcher.group(2);
         }
 
         final Matcher matcher = BLOB_PATTERN.matcher(blobName);
@@ -52,10 +59,18 @@ public class DocumentBlobNameResolver {
 
     /**
      * Returns the clientId encoded in a namespaced blob name, or {@code null} when the name has no
-     * prefix (defer to the Table row for ownership). Prefix extraction is not yet implemented.
+     * prefix (defer to the Table row for ownership).
      */
     public String getClientId(final String blobName) {
-        // TODO: extract the clientId from the c={clientId}/ prefix when present
+        if (isNullOrEmpty(blobName)) {
+            return null;
+        }
+
+        final Matcher prefixedMatcher = PREFIXED_BLOB_PATTERN.matcher(blobName);
+        if (prefixedMatcher.matches()) {
+            return prefixedMatcher.group(1);
+        }
+
         return null;
     }
 }

--- a/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/utils/DocumentBlobNameResolver.java
+++ b/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/utils/DocumentBlobNameResolver.java
@@ -14,7 +14,8 @@ import java.util.regex.Pattern;
 public class DocumentBlobNameResolver {
 
     private static final Pattern BLOB_PATTERN = Pattern.compile("^([^_]+)_([0-9]{8})\\.[^.]+$");
-    private static final Pattern PREFIXED_BLOB_PATTERN = Pattern.compile("^c=([^/]+)/([^_]+)_([0-9]{8})\\.[^.]+$");
+    private static final Pattern PREFIXED_BLOB_PATTERN = Pattern.compile("^c=([^/]+)/([^/_]+)_([0-9]{8})\\.[^.]+$");
+    private static final String CLIENT_PREFIX_MARKER = "c=";
     private static final String INVALID_BLOB_NAME_ERROR_MSG = "Invalid blobName: '%s' format, expected format is documentId_yyyyMMdd.fileExtension";
     private static final String DEFAULT_DATETIME_FORMAT = "yyyyMMdd";
 
@@ -47,6 +48,11 @@ public class DocumentBlobNameResolver {
         final Matcher prefixedMatcher = PREFIXED_BLOB_PATTERN.matcher(blobName);
         if (prefixedMatcher.matches()) {
             return prefixedMatcher.group(2);
+        }
+        // A name that announces a client prefix must parse as one — the flat pattern's permissive
+        // documentId group would otherwise swallow the whole prefixed path as a garbage documentId.
+        if (blobName.startsWith(CLIENT_PREFIX_MARKER)) {
+            throw new IllegalArgumentException(format(INVALID_BLOB_NAME_ERROR_MSG, blobName));
         }
 
         final Matcher matcher = BLOB_PATTERN.matcher(blobName);

--- a/ai-document-metadata-check-function/src/test/java/uk/gov/moj/cp/metadata/check/DocumentBlobTriggerFunctionTest.java
+++ b/ai-document-metadata-check-function/src/test/java/uk/gov/moj/cp/metadata/check/DocumentBlobTriggerFunctionTest.java
@@ -87,11 +87,11 @@ class DocumentBlobTriggerFunctionTest {
             when(document.getDocumentName()).thenReturn("doc.json");
             when(document.getMetadata()).thenReturn("{\"version\":\"1.0\"}");
 
-            when(documentUploadService.getDocument(documentId)).thenReturn(document);
+            when(documentUploadService.getDocument(null, documentId)).thenReturn(document);
 
             function.run(new byte[]{}, blobName, outputBinding);
 
-            verify(documentUploadService).getDocument(documentId);
+            verify(documentUploadService).getDocument(null, documentId);
             verify(documentUploadService).updateDocumentAwaitingIngestion(documentId);
 
             final ArgumentCaptor<String> queueMessageCaptor = ArgumentCaptor.forClass(String.class);
@@ -123,7 +123,7 @@ class DocumentBlobTriggerFunctionTest {
             when(document.getDocumentId()).thenReturn(documentId);
             when(document.getDocumentName()).thenReturn("doc.json");
             when(document.getMetadata()).thenReturn("{\"version\":\"1.0\"}");
-            when(documentUploadService.getDocument(documentId)).thenReturn(document);
+            when(documentUploadService.getDocument(null, documentId)).thenReturn(document);
 
             final long maxSizeLimit = 80L * 1024 * 1024;
             final long documentSize = 81L * 1024 * 1024;
@@ -131,7 +131,7 @@ class DocumentBlobTriggerFunctionTest {
 
             function.run(new byte[]{}, blobName, outputBinding);
 
-            verify(documentUploadService).getDocument(documentId);
+            verify(documentUploadService).getDocument(null, documentId);
             verify(documentUploadService).updateDocumentFileSizeOverLimit(documentId, documentSize, maxSizeLimit);
             verifyNoInteractions(outputBinding);
         }
@@ -156,7 +156,7 @@ class DocumentBlobTriggerFunctionTest {
             when(document.getDocumentId()).thenReturn(documentId);
             when(document.getDocumentName()).thenReturn("doc.json");
             when(document.getMetadata()).thenReturn("{\"version\":\"1.0\"}");
-            when(documentUploadService.getDocument(documentId)).thenReturn(document);
+            when(documentUploadService.getDocument("client-1", documentId)).thenReturn(document);
 
             function.run(new byte[]{}, prefixedBlobName, outputBinding);
 
@@ -183,7 +183,7 @@ class DocumentBlobTriggerFunctionTest {
             when(document.getDocumentId()).thenReturn(documentId);
             when(document.getDocumentName()).thenReturn("doc.json");
             when(document.getMetadata()).thenReturn("{\"version\":\"1.0\"}");
-            when(documentUploadService.getDocument(documentId)).thenReturn(document);
+            when(documentUploadService.getDocument(null, documentId)).thenReturn(document);
 
             function.run(new byte[]{}, blobName, outputBinding);
 
@@ -208,7 +208,7 @@ class DocumentBlobTriggerFunctionTest {
         // invalid JSON to trigger stringToMap failure
         when(document.getMetadata()).thenReturn("invalid-json");
 
-        when(documentUploadService.getDocument(documentId)).thenReturn(document);
+        when(documentUploadService.getDocument(null, documentId)).thenReturn(document);
 
         final IllegalStateException exception = assertThrows(IllegalStateException.class,
                 () -> function.run(new byte[]{}, blobName, outputBinding));

--- a/ai-document-metadata-check-function/src/test/java/uk/gov/moj/cp/metadata/check/DocumentBlobTriggerFunctionTest.java
+++ b/ai-document-metadata-check-function/src/test/java/uk/gov/moj/cp/metadata/check/DocumentBlobTriggerFunctionTest.java
@@ -3,6 +3,7 @@ package uk.gov.moj.cp.metadata.check;
 import static java.time.ZonedDateTime.now;
 import static java.time.ZonedDateTime.parse;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -133,6 +134,65 @@ class DocumentBlobTriggerFunctionTest {
             verify(documentUploadService).getDocument(documentId);
             verify(documentUploadService).updateDocumentFileSizeOverLimit(documentId, documentSize, maxSizeLimit);
             verifyNoInteractions(outputBinding);
+        }
+    }
+
+    @Test
+    void shouldCarryParsedClientId_whenBlobNameIsClientPrefixed() throws JsonProcessingException {
+        try (MockedStatic<EnvVarUtil> mockedEnvVarUtil = mockStatic(EnvVarUtil.class)) {
+            mockedEnvVarUtil.when(() -> getRequiredEnv(AI_RAG_SERVICE_BLOB_STORAGE_ENDPOINT)).thenReturn("http://blob.web.com/");
+            mockedEnvVarUtil.when(() -> getRequiredEnv(STORAGE_ACCOUNT_BLOB_CONTAINER_NAME_DOCUMENT_UPLOAD)).thenReturn("doc-upload");
+
+            final String prefixedBlobName = "c=client-1/123_20260226.json";
+            final BlobClient blobClient = mock(BlobClient.class);
+            when(blobClientService.getBlobClient(prefixedBlobName)).thenReturn(blobClient);
+            when(blobClient.getProperties()).thenReturn(blobProperties);
+
+            when(documentBlobNameResolver.getDocumentId(prefixedBlobName)).thenReturn(documentId);
+            when(documentBlobNameResolver.getClientId(prefixedBlobName)).thenReturn("client-1");
+            when(blobClientService.isBlobAvailable(prefixedBlobName)).thenReturn(true);
+
+            final DocumentIngestionOutcome document = mock(DocumentIngestionOutcome.class);
+            when(document.getDocumentId()).thenReturn(documentId);
+            when(document.getDocumentName()).thenReturn("doc.json");
+            when(document.getMetadata()).thenReturn("{\"version\":\"1.0\"}");
+            when(documentUploadService.getDocument(documentId)).thenReturn(document);
+
+            function.run(new byte[]{}, prefixedBlobName, outputBinding);
+
+            final ArgumentCaptor<String> queueMessageCaptor = ArgumentCaptor.forClass(String.class);
+            verify(outputBinding).setValue(queueMessageCaptor.capture());
+            final QueueIngestionMetadata queueIngestionMetadata = getObjectMapper()
+                    .readValue(queueMessageCaptor.getValue(), QueueIngestionMetadata.class);
+
+            assertThat(queueIngestionMetadata.clientId(), is("client-1"));
+        }
+    }
+
+    @Test
+    void shouldCarryNullClientId_whenBlobNameIsFlat() throws JsonProcessingException {
+        try (MockedStatic<EnvVarUtil> mockedEnvVarUtil = mockStatic(EnvVarUtil.class)) {
+            mockedEnvVarUtil.when(() -> getRequiredEnv(AI_RAG_SERVICE_BLOB_STORAGE_ENDPOINT)).thenReturn("http://blob.web.com/");
+            mockedEnvVarUtil.when(() -> getRequiredEnv(STORAGE_ACCOUNT_BLOB_CONTAINER_NAME_DOCUMENT_UPLOAD)).thenReturn("doc-upload");
+
+            when(documentBlobNameResolver.getDocumentId(blobName)).thenReturn(documentId);
+            when(documentBlobNameResolver.getClientId(blobName)).thenReturn(null);
+            when(blobClientService.isBlobAvailable(blobName)).thenReturn(true);
+
+            final DocumentIngestionOutcome document = mock(DocumentIngestionOutcome.class);
+            when(document.getDocumentId()).thenReturn(documentId);
+            when(document.getDocumentName()).thenReturn("doc.json");
+            when(document.getMetadata()).thenReturn("{\"version\":\"1.0\"}");
+            when(documentUploadService.getDocument(documentId)).thenReturn(document);
+
+            function.run(new byte[]{}, blobName, outputBinding);
+
+            final ArgumentCaptor<String> queueMessageCaptor = ArgumentCaptor.forClass(String.class);
+            verify(outputBinding).setValue(queueMessageCaptor.capture());
+            final QueueIngestionMetadata queueIngestionMetadata = getObjectMapper()
+                    .readValue(queueMessageCaptor.getValue(), QueueIngestionMetadata.class);
+
+            assertThat(queueIngestionMetadata.clientId(), is(nullValue()));
         }
     }
 

--- a/ai-document-metadata-check-function/src/test/java/uk/gov/moj/cp/metadata/check/utils/DocumentBlobNameResolverTest.java
+++ b/ai-document-metadata-check-function/src/test/java/uk/gov/moj/cp/metadata/check/utils/DocumentBlobNameResolverTest.java
@@ -1,6 +1,7 @@
 package uk.gov.moj.cp.metadata.check.utils;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -74,5 +75,65 @@ public class DocumentBlobNameResolverTest {
         final String blobName = resolver.getBlobName(documentId, extension);
 
         assertThat(blobName.contains(expectedDate), is(true));
+    }
+
+    @Test
+    void getBlobName_shouldReturnClientPrefixedFormat_whenClientIdPresent() {
+        final String clientId = "client-1";
+        final String documentId = "doc123";
+        final String extension = "pdf";
+
+        final String blobName = resolver.getBlobName(clientId, documentId, extension);
+
+        assertThat(blobName.matches("^c=client-1/doc123_[0-9]{8}\\.pdf$"), is(true));
+    }
+
+    @Test
+    void getBlobName_shouldReturnFlatFormat_whenClientIdIsNull() {
+        final String documentId = "doc123";
+        final String extension = "pdf";
+
+        final String prefixedOverloadResult = resolver.getBlobName(null, documentId, extension);
+        final String flatResult = resolver.getBlobName(documentId, extension);
+
+        assertThat(prefixedOverloadResult, is(flatResult));
+        assertThat(prefixedOverloadResult.matches("^doc123_[0-9]{8}\\.pdf$"), is(true));
+    }
+
+    @Test
+    void getBlobName_shouldReturnFlatFormat_whenClientIdIsEmpty() {
+        final String documentId = "doc123";
+        final String extension = "pdf";
+
+        final String prefixedOverloadResult = resolver.getBlobName("", documentId, extension);
+
+        assertThat(prefixedOverloadResult.matches("^doc123_[0-9]{8}\\.pdf$"), is(true));
+    }
+
+    @Test
+    void getDocumentId_shouldReturnDocumentId_whenClientPrefixedBlobName() {
+        final String blobName = "c=client-1/doc123_20240101.pdf";
+
+        final String result = resolver.getDocumentId(blobName);
+
+        assertThat(result, is("doc123"));
+    }
+
+    @Test
+    void getClientId_shouldReturnClientId_whenClientPrefixedBlobName() {
+        final String blobName = "c=client-1/doc123_20240101.pdf";
+
+        final String result = resolver.getClientId(blobName);
+
+        assertThat(result, is("client-1"));
+    }
+
+    @Test
+    void getClientId_shouldReturnNull_whenFlatBlobName() {
+        final String blobName = "doc123_20240101.pdf";
+
+        final String result = resolver.getClientId(blobName);
+
+        assertThat(result, is(nullValue()));
     }
 }

--- a/ai-document-metadata-check-function/src/test/java/uk/gov/moj/cp/metadata/check/utils/DocumentBlobNameResolverTest.java
+++ b/ai-document-metadata-check-function/src/test/java/uk/gov/moj/cp/metadata/check/utils/DocumentBlobNameResolverTest.java
@@ -136,4 +136,22 @@ public class DocumentBlobNameResolverTest {
 
         assertThat(result, is(nullValue()));
     }
+
+    @Test
+    void getDocumentId_shouldThrowException_whenNestedPrefixedBlobName() {
+        // A name announcing a client prefix must parse as exactly one prefix segment — the permissive
+        // flat pattern must not swallow a malformed prefixed path as a garbage documentId.
+        final String blobName = "c=client-a/c=client-b/doc123_20240101.pdf";
+
+        assertThrows(IllegalArgumentException.class, () -> resolver.getDocumentId(blobName));
+    }
+
+    @Test
+    void getClientId_shouldReturnNull_whenNestedPrefixedBlobName() {
+        final String blobName = "c=client-a/c=client-b/doc123_20240101.pdf";
+
+        final String result = resolver.getClientId(blobName);
+
+        assertThat(result, is(nullValue()));
+    }
 }

--- a/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/storage/BlobNamespace.java
+++ b/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/storage/BlobNamespace.java
@@ -1,0 +1,48 @@
+package uk.gov.moj.cp.ai.storage;
+
+import static java.lang.String.format;
+import static uk.gov.moj.cp.ai.util.StringUtil.isNullOrEmpty;
+
+/**
+ * The blob-storage namespace convention for client-scoped blobs: every blob belonging to a client
+ * lives under a virtual directory of the form {@code c={clientId}/}, e.g.
+ * {@code c=8f7b.../doc123_20260722.pdf}. Blobs written before client scoping existed keep their
+ * flat legacy names in the same containers.
+ *
+ * <p>A {@code key=} style marker is used rather than a bare {@code {clientId}/} directory because:
+ * <ul>
+ *   <li><b>Unambiguous dual-shape parsing.</b> Containers hold both legacy flat names and
+ *       client-prefixed names during the transition. A name starting with the marker is
+ *       definitively client-prefixed (and is rejected if it does not parse as exactly that),
+ *       while a flat name can never be mistaken for one. An anonymous leading directory would
+ *       make the two shapes indistinguishable by inspection.</li>
+ *   <li><b>Self-describing paths.</b> In storage browsers, logs and SAS URLs the segment
+ *       announces what it is — the same idiom as data-lake partition paths such as
+ *       {@code date=2026-07-22/}.</li>
+ *   <li><b>Composable namespaces.</b> Additional keyed segments can be introduced later without
+ *       ambiguity, which stacked anonymous directories would not allow.</li>
+ *   <li><b>Precise prefix operations.</b> Per-client lifecycle rules, listings and SAS scopes
+ *       filter on {@code c={clientId}/}, which cannot collide with a document name that merely
+ *       starts with the same characters.</li>
+ * </ul>
+ *
+ * <p>The blob path is a convenience namespace only — the Table Storage row remains the
+ * authoritative record of which client owns a document.
+ */
+public final class BlobNamespace {
+
+    /** Marker announcing a client-namespace segment at the start of a blob name. */
+    public static final String CLIENT_PREFIX_MARKER = "c=";
+
+    private BlobNamespace() {
+        // Utility class
+    }
+
+    /**
+     * Places a blob name under the client's namespace when a clientId is supplied; returns the
+     * name unchanged when it is null/blank (legacy flat shape).
+     */
+    public static String applyClientPrefix(final String clientId, final String blobName) {
+        return isNullOrEmpty(clientId) ? blobName : format("%s%s/%s", CLIENT_PREFIX_MARKER, clientId, blobName);
+    }
+}

--- a/ai-document-shared-artefacts/src/test/java/uk/gov/moj/cp/ai/storage/BlobNamespaceTest.java
+++ b/ai-document-shared-artefacts/src/test/java/uk/gov/moj/cp/ai/storage/BlobNamespaceTest.java
@@ -1,0 +1,31 @@
+package uk.gov.moj.cp.ai.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Specs for the client blob-namespace helper: a supplied clientId places the name under the
+ * client's virtual directory; a null/blank clientId leaves the flat legacy name untouched.
+ */
+class BlobNamespaceTest {
+
+    @Test
+    @DisplayName("applyClientPrefix places the name under the client's namespace when a clientId is supplied")
+    void shouldPrefix_whenClientIdSupplied() {
+        assertEquals("c=client-1/doc_20260722.pdf", BlobNamespace.applyClientPrefix("client-1", "doc_20260722.pdf"));
+    }
+
+    @Test
+    @DisplayName("applyClientPrefix leaves the name unchanged when clientId is null")
+    void shouldNotPrefix_whenClientIdNull() {
+        assertEquals("doc_20260722.pdf", BlobNamespace.applyClientPrefix(null, "doc_20260722.pdf"));
+    }
+
+    @Test
+    @DisplayName("applyClientPrefix leaves the name unchanged when clientId is blank")
+    void shouldNotPrefix_whenClientIdBlank() {
+        assertEquals("doc_20260722.pdf", BlobNamespace.applyClientPrefix(" ", "doc_20260722.pdf"));
+    }
+}


### PR DESCRIPTION
**Jira:** DD-42980 (sub-task of DD-42722)

Story MTDI05 (Phase 1 — client-aware storage), the final Phase 1 story of the multi-client data isolation initiative. **Merge-safe:** no production caller supplies a client scope yet, so every blob keeps its flat legacy name and all current behaviour is unchanged (locked by regression tests).

## What's in this PR
- `DocumentBlobNameResolver`: client-namespaced blob names (`c={clientId}/{documentId}_{yyyyMMdd}.{ext}`) when a client scope is supplied; dual-path parsing with the prefixed pattern checked before the (untouched) flat pattern — a prefixed name would otherwise spuriously match the flat regex and yield a garbage documentId; new `getClientId` returning null for flat names; malformed/nested prefixed names are rejected rather than falling through.
- `DocumentBlobTriggerFunction`: parses the clientId from the blob path, looks the status row up by `(clientId, documentId)` via the merged client-aware table service, and threads the clientId onto the ingestion queue payload. The Table row remains the authoritative ownership record.
- `ChunkUtil`: answer/input-chunk blob names gain client-prefixed variants (callers pass null until the wiring story).

## Test evidence
- A-TDD: 6 tests scaffolded red first; implementation + review fixes turned them green; flat-path regression locks green throughout, plus new negative tests for malformed nested prefixed names.
- metadata-check 52, answer-retrieval 165 — 0 failures; whole-reactor build green including the no-test harness-eval module; remaining modules re-run green (shared-artefacts 236, ingestion 55, scoring 23, status-check 4, migration-tool 62).
- Structured code review: approve with minor comments — the one substantive finding (the client-aware row lookup deferred without documentation) was resolved by implementing it now, per the reviewer's preferred option.
- Branch rebased onto main after the three earlier Phase 1 merges; reviewer explicitly verified rebase integrity (no reverts of the merged idempotency/search-filter/migration changes).
- SDK behaviour confirm from the story DoD: `BlobClientService.getSasUrl`/`getBlobClient` accept `/`-containing blob names (virtual directories) without change.

## Design & stories
`docs/pipeline/DD-42722-multi-tenant-data-isolation/` — [design](https://github.com/hmcts/cp-ai-rag-service/blob/main/docs/pipeline/DD-42722-multi-tenant-data-isolation/02-design.md) §D, [stories](https://github.com/hmcts/cp-ai-rag-service/blob/main/docs/pipeline/DD-42722-multi-tenant-data-isolation/03-stories.md) §MTDI05.