### PR TITLE
Client-identity wiring cleanups from post-merge review

### DIFF
--- a/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/AnswerGenerationFunction.java
+++ b/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/AnswerGenerationFunction.java
@@ -170,8 +170,8 @@ public class AnswerGenerationFunction {
             final AnswerGenerationQueuePayload validPayload = payload;
             // A payload-carried clientId is re-validated defensively before use; a legacy message
             // without one keeps the null-scoped (legacy) claim, search and writes.
-            clientId = validatedClientId(validPayload.clientId());
-            final String claimClientId = clientId;
+            final String claimClientId = ClientId.requireValidOrNull(payload.clientId());
+            clientId = claimClientId;
 
             LOGGER.info("Starting answer generation for transactionId '{}'", transactionId);
 
@@ -191,11 +191,6 @@ public class AnswerGenerationFunction {
         } catch (Exception e) {
             handleClaimFailure(payload, clientId, e, dequeueCount, maxDequeueCount, startTime);
         }
-    }
-
-    /** Legacy null clientId stays null; a present one is re-validated as a UUID before use. */
-    private static String validatedClientId(final String clientId) {
-        return isNullOrEmpty(clientId) ? null : ClientId.requireValid(clientId);
     }
 
     /**

--- a/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/GetAnswerGenerationResultFunction.java
+++ b/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/GetAnswerGenerationResultFunction.java
@@ -64,10 +64,6 @@ public class GetAnswerGenerationResultFunction {
         clientIdentityResolver = HeaderClientIdentityResolver.fromEnvironment();
     }
 
-    public GetAnswerGenerationResultFunction(final AnswerGenerationTableService answerGenerationTableService, final BlobPersistenceService blobPersistenceInputChunksService) {
-        this(answerGenerationTableService, blobPersistenceInputChunksService, null);
-    }
-
     public GetAnswerGenerationResultFunction(final AnswerGenerationTableService answerGenerationTableService,
                                              final BlobPersistenceService blobPersistenceInputChunksService,
                                              final ClientIdentityResolver clientIdentityResolver) {

--- a/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/InitiateAnswerGenerationFunction.java
+++ b/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/InitiateAnswerGenerationFunction.java
@@ -59,10 +59,6 @@ public class InitiateAnswerGenerationFunction {
         clientIdentityResolver = HeaderClientIdentityResolver.fromEnvironment();
     }
 
-    public InitiateAnswerGenerationFunction(final AnswerGenerationTableService answerGenerationTableService) {
-        this(answerGenerationTableService, null);
-    }
-
     public InitiateAnswerGenerationFunction(final AnswerGenerationTableService answerGenerationTableService,
                                             final ClientIdentityResolver clientIdentityResolver) {
         this.answerGenerationTableService = answerGenerationTableService;

--- a/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/SyncAnswerGenerationFunction.java
+++ b/ai-document-answer-retrieval-function/src/main/java/uk/gov/moj/cp/retrieval/SyncAnswerGenerationFunction.java
@@ -86,13 +86,6 @@ public class SyncAnswerGenerationFunction {
     SyncAnswerGenerationFunction(final EmbedDataService embedDataService, final AzureAISearchService searchService,
                                  final ResponseGenerationService responseGenerationService,
                                  final BlobPersistenceService blobPersistenceService,
-                                 final CitationGuardMode guardMode) {
-        this(embedDataService, searchService, responseGenerationService, blobPersistenceService, guardMode, null);
-    }
-
-    SyncAnswerGenerationFunction(final EmbedDataService embedDataService, final AzureAISearchService searchService,
-                                 final ResponseGenerationService responseGenerationService,
-                                 final BlobPersistenceService blobPersistenceService,
                                  final CitationGuardMode guardMode,
                                  final ClientIdentityResolver clientIdentityResolver) {
         this.embedDataService = embedDataService;

--- a/ai-document-answer-retrieval-function/src/test/java/uk/gov/moj/cp/retrieval/GetAnswerGenerationResultFunctionClientIdentityTest.java
+++ b/ai-document-answer-retrieval-function/src/test/java/uk/gov/moj/cp/retrieval/GetAnswerGenerationResultFunctionClientIdentityTest.java
@@ -106,7 +106,7 @@ class GetAnswerGenerationResultFunctionClientIdentityTest {
     void shouldUseLegacyLookup_whenEnforcementOff() throws Exception {
         final String transactionId = randomUUID().toString();
         final GetAnswerGenerationResultFunction defaultFunction =
-                new GetAnswerGenerationResultFunction(tableService, blobPersistenceInputChunksService);
+                new GetAnswerGenerationResultFunction(tableService, blobPersistenceInputChunksService, null);
 
         defaultFunction.run(request, transactionId, context);
 

--- a/ai-document-answer-retrieval-function/src/test/java/uk/gov/moj/cp/retrieval/InitiateAnswerGenerationFunctionClientIdentityTest.java
+++ b/ai-document-answer-retrieval-function/src/test/java/uk/gov/moj/cp/retrieval/InitiateAnswerGenerationFunctionClientIdentityTest.java
@@ -118,7 +118,7 @@ class InitiateAnswerGenerationFunctionClientIdentityTest {
     @DisplayName("flag off (default resolver) keeps the legacy null-scoped pending row")
     void shouldPersistLegacyRow_whenEnforcementOff() throws Exception {
         final InitiateAnswerGenerationFunction defaultFunction =
-                new InitiateAnswerGenerationFunction(answerGenerationTableService);
+                new InitiateAnswerGenerationFunction(answerGenerationTableService, null);
         when(request.getBody()).thenReturn(validRequest());
         mockResponse();
 

--- a/ai-document-answer-retrieval-function/src/test/java/uk/gov/moj/cp/retrieval/SyncAnswerGenerationFunctionClientIdentityTest.java
+++ b/ai-document-answer-retrieval-function/src/test/java/uk/gov/moj/cp/retrieval/SyncAnswerGenerationFunctionClientIdentityTest.java
@@ -135,7 +135,7 @@ class SyncAnswerGenerationFunctionClientIdentityTest {
     @DisplayName("flag off (default resolver) keeps the legacy null-scoped search")
     void shouldSearchWithoutScope_whenEnforcementOff() throws Exception {
         final SyncAnswerGenerationFunction defaultFunction = new SyncAnswerGenerationFunction(
-                embedDataService, searchService, responseGenerationService, blobPersistenceService, DELIVER);
+                embedDataService, searchService, responseGenerationService, blobPersistenceService, DELIVER, null);
         stubHappyPath();
 
         defaultFunction.run(request, outputBinding, context);

--- a/ai-document-answer-retrieval-function/src/test/java/uk/gov/moj/cp/retrieval/SyncAnswerGenerationFunctionTest.java
+++ b/ai-document-answer-retrieval-function/src/test/java/uk/gov/moj/cp/retrieval/SyncAnswerGenerationFunctionTest.java
@@ -80,7 +80,7 @@ class SyncAnswerGenerationFunctionTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        function = new SyncAnswerGenerationFunction(mockEmbedDataService, mockSearchService, mockResponseGenerationService, mockBlobPersistenceService, DELIVER);
+        function = new SyncAnswerGenerationFunction(mockEmbedDataService, mockSearchService, mockResponseGenerationService, mockBlobPersistenceService, DELIVER, null);
     }
 
     @Test
@@ -199,7 +199,7 @@ class SyncAnswerGenerationFunctionTest {
     @Test
     void run_DeliversDegradedAnswerAndScores_WhenGuardTrips_InDeliverMode() throws SearchServiceException, ChatServiceException {
         function = new SyncAnswerGenerationFunction(mockEmbedDataService, mockSearchService,
-                mockResponseGenerationService, mockBlobPersistenceService, DELIVER);
+                mockResponseGenerationService, mockBlobPersistenceService, DELIVER, null);
         stubDegradedGeneration();
 
         function.run(mockRequest, mockOutputBinding, mockContext);
@@ -215,7 +215,7 @@ class SyncAnswerGenerationFunctionTest {
     @Test
     void run_ReturnsSentinelAndSkipsScoring_WhenGuardTrips_InRejectMode() throws SearchServiceException, ChatServiceException {
         function = new SyncAnswerGenerationFunction(mockEmbedDataService, mockSearchService,
-                mockResponseGenerationService, mockBlobPersistenceService, CitationGuardMode.REJECT);
+                mockResponseGenerationService, mockBlobPersistenceService, CitationGuardMode.REJECT, null);
         stubDegradedGeneration();
 
         function.run(mockRequest, mockOutputBinding, mockContext);

--- a/ai-document-ingestion-function/src/main/java/uk/gov/moj/cp/ingestion/DocumentIngestionFunction.java
+++ b/ai-document-ingestion-function/src/main/java/uk/gov/moj/cp/ingestion/DocumentIngestionFunction.java
@@ -84,7 +84,7 @@ public class DocumentIngestionFunction {
         // Validated once, before anything else: a legacy message without a clientId keeps the
         // null-scoped claim; an invalid value fails the invocation here (redelivery, then poison)
         // so a corrupt message never enters the pipeline.
-        final String clientId = validatedClientId(queueIngestionMetadata.clientId());
+        final String clientId = ClientId.requireValidOrNull(queueIngestionMetadata.clientId());
         try {
             LOGGER.info("Parsed ingestion metadata - ID: {}, Name: {}, Blob URL: {}",
                     documentId,
@@ -150,11 +150,6 @@ public class DocumentIngestionFunction {
         }
         LOGGER.error("Document ingestion failed during idempotency claim for documentId='{}'", queueIngestionMetadata.documentId(), e);
         documentIngestionOrchestrator.processQueueMessageFailedIfSafe(queueIngestionMetadata, clientId);
-    }
-
-    /** Legacy null clientId stays null; a present one is re-validated as a UUID before use. */
-    private static String validatedClientId(final String clientId) {
-        return isNullOrEmpty(clientId) ? null : ClientId.requireValid(clientId);
     }
 
     private QueueIngestionMetadata toQueueIngestionMetadata(final String queueMessage) {

--- a/ai-document-ingestion-function/src/main/java/uk/gov/moj/cp/ingestion/service/ChunkEmbeddingService.java
+++ b/ai-document-ingestion-function/src/main/java/uk/gov/moj/cp/ingestion/service/ChunkEmbeddingService.java
@@ -107,17 +107,8 @@ public class ChunkEmbeddingService {
                     int chunkSize = chunkedEntry.chunk().length();
                     int estimatedTokens = chunkSize / 4;
 
-                    ChunkedEntry enrichedEntry = ChunkedEntry.builder()
-                            .id(chunkedEntry.id())
-                            .documentId(chunkedEntry.documentId())
-                            .chunk(chunkedEntry.chunk())
+                    ChunkedEntry enrichedEntry = chunkedEntry.toBuilder()
                             .chunkVector(vector)
-                            .documentFileName(chunkedEntry.documentFileName())
-                            .pageNumber(chunkedEntry.pageNumber())
-                            .chunkIndex(chunkedEntry.chunkIndex())
-                            .documentFileUrl(chunkedEntry.documentFileUrl())
-                            .customMetadata(chunkedEntry.customMetadata())
-                            .clientId(chunkedEntry.clientId())
                             .build();
 
                     chunkedEntries.set(originalIndex, enrichedEntry);

--- a/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/DocumentUploadFunction.java
+++ b/ai-document-metadata-check-function/src/main/java/uk/gov/moj/cp/metadata/check/DocumentUploadFunction.java
@@ -78,12 +78,6 @@ public class DocumentUploadFunction {
 
     public DocumentUploadFunction(final BlobClientService blobClientService,
                                   final DocumentUploadService documentUploadService,
-                                  final DocumentBlobNameResolver documentBlobNameResolver) {
-        this(blobClientService, documentUploadService, documentBlobNameResolver, null);
-    }
-
-    public DocumentUploadFunction(final BlobClientService blobClientService,
-                                  final DocumentUploadService documentUploadService,
                                   final DocumentBlobNameResolver documentBlobNameResolver,
                                   final ClientIdentityResolver clientIdentityResolver) {
         this.urlExpiryMinutes = parseInt(DEFAULT_URL_EXPIRY_MINUTES);

--- a/ai-document-metadata-check-function/src/test/java/uk/gov/moj/cp/metadata/check/DocumentUploadFunctionClientIdentityTest.java
+++ b/ai-document-metadata-check-function/src/test/java/uk/gov/moj/cp/metadata/check/DocumentUploadFunctionClientIdentityTest.java
@@ -118,7 +118,7 @@ class DocumentUploadFunctionClientIdentityTest {
         // A default, environment-built resolver with the flag unset resolves to an unenforced context,
         // so the legacy null-scoped lookup and success path are preserved byte-for-byte.
         final DocumentUploadFunction defaultFunction =
-                new DocumentUploadFunction(blobClientService, documentUploadService, documentBlobNameResolver);
+                new DocumentUploadFunction(blobClientService, documentUploadService, documentBlobNameResolver, null);
         final DocumentUploadRequest body = validRequest();
         when(request.getBody()).thenReturn(body);
         when(documentBlobNameResolver.getBlobName(any(), any())).thenReturn("blob.pdf");

--- a/ai-document-metadata-check-function/src/test/java/uk/gov/moj/cp/metadata/check/DocumentUploadFunctionTest.java
+++ b/ai-document-metadata-check-function/src/test/java/uk/gov/moj/cp/metadata/check/DocumentUploadFunctionTest.java
@@ -68,7 +68,7 @@ public class DocumentUploadFunctionTest {
 
     @BeforeEach
     void setup() {
-        function = new DocumentUploadFunction(blobClientService, documentUploadService, documentBlobNameResolver);
+        function = new DocumentUploadFunction(blobClientService, documentUploadService, documentBlobNameResolver, null);
     }
 
     @Test

--- a/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/IndexCopier.java
+++ b/ai-document-migration-tool/src/main/java/uk/gov/moj/cp/migration/index/IndexCopier.java
@@ -188,16 +188,7 @@ final class IndexCopier {
 
     /** Copies an entry with the configured clientId set and every other field preserved. */
     private ChunkedEntry withClientId(final ChunkedEntry source) {
-        return ChunkedEntry.builder()
-                .id(source.id())
-                .documentId(source.documentId())
-                .chunk(source.chunk())
-                .chunkVector(source.chunkVector())
-                .documentFileName(source.documentFileName())
-                .pageNumber(source.pageNumber())
-                .chunkIndex(source.chunkIndex())
-                .documentFileUrl(source.documentFileUrl())
-                .customMetadata(source.customMetadata())
+        return source.toBuilder()
                 .clientId(clientIdOverride)
                 .build();
     }

--- a/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/client/identity/ClientId.java
+++ b/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/client/identity/ClientId.java
@@ -1,5 +1,7 @@
 package uk.gov.moj.cp.ai.client.identity;
 
+import static uk.gov.moj.cp.ai.util.StringUtil.isNullOrEmpty;
+
 import uk.gov.moj.cp.ai.util.UuidUtil;
 
 /**
@@ -22,5 +24,10 @@ public final class ClientId {
             throw new ClientIdentityException("Missing or invalid client identity");
         }
         return clientId;
+    }
+
+    /** Legacy null/empty clientId stays null; a present one is validated as a UUID before use. */
+    public static String requireValidOrNull(final String clientId) {
+        return isNullOrEmpty(clientId) ? null : requireValid(clientId);
     }
 }

--- a/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/model/ChunkedEntry.java
+++ b/ai-document-shared-artefacts/src/main/java/uk/gov/moj/cp/ai/model/ChunkedEntry.java
@@ -115,4 +115,25 @@ public record ChunkedEntry(
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * A {@link Builder} pre-populated with every field of this entry, for copy-with-override sites.
+     * Copy sites MUST use this rather than rebuilding the entry field-by-field: a field-by-field
+     * rebuild silently drops any field the author forgot to carry over (a class of bug that has
+     * bitten this record before), whereas {@code toBuilder()} copies all fields by construction so
+     * only the fields explicitly overridden can change.
+     */
+    public Builder toBuilder() {
+        return new Builder()
+                .id(id)
+                .documentId(documentId)
+                .chunk(chunk)
+                .chunkVector(chunkVector)
+                .documentFileName(documentFileName)
+                .pageNumber(pageNumber)
+                .chunkIndex(chunkIndex)
+                .documentFileUrl(documentFileUrl)
+                .customMetadata(customMetadata)
+                .clientId(clientId);
+    }
 }

--- a/ai-document-shared-artefacts/src/test/java/uk/gov/moj/cp/ai/client/identity/ClientIdTest.java
+++ b/ai-document-shared-artefacts/src/test/java/uk/gov/moj/cp/ai/client/identity/ClientIdTest.java
@@ -2,6 +2,7 @@ package uk.gov.moj.cp.ai.client.identity;
 
 import static java.util.UUID.randomUUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.DisplayName;
@@ -44,5 +45,37 @@ class ClientIdTest {
         final String clientId = randomUUID().toString();
 
         assertEquals(clientId, ClientId.requireValid(clientId));
+    }
+
+    @Test
+    @DisplayName("requireValidOrNull(null) → null")
+    void shouldReturnNull_whenNull() {
+        assertNull(ClientId.requireValidOrNull(null));
+    }
+
+    @Test
+    @DisplayName("requireValidOrNull(\"\") → null")
+    void shouldReturnNull_whenEmpty() {
+        assertNull(ClientId.requireValidOrNull(""));
+    }
+
+    @Test
+    @DisplayName("requireValidOrNull(blank) → null")
+    void shouldReturnNull_whenBlank() {
+        assertNull(ClientId.requireValidOrNull("   "));
+    }
+
+    @Test
+    @DisplayName("requireValidOrNull(valid UUID) → returns the value unchanged")
+    void shouldReturnValue_whenValidUuidOrNull() {
+        final String clientId = randomUUID().toString();
+
+        assertEquals(clientId, ClientId.requireValidOrNull(clientId));
+    }
+
+    @Test
+    @DisplayName("requireValidOrNull(non-UUID) → ClientIdentityException")
+    void shouldThrow_whenPresentButNotUuid() {
+        assertThrows(ClientIdentityException.class, () -> ClientId.requireValidOrNull("not-a-uuid"));
     }
 }

--- a/ai-document-shared-artefacts/src/test/java/uk/gov/moj/cp/ai/model/ChunkedEntryTest.java
+++ b/ai-document-shared-artefacts/src/test/java/uk/gov/moj/cp/ai/model/ChunkedEntryTest.java
@@ -69,6 +69,51 @@ class ChunkedEntryTest {
     }
 
     @Test
+    @DisplayName("toBuilder().build() copies every field, producing an equal entry")
+    void shouldRoundTripAllFields_viaToBuilder() {
+        final ChunkedEntry original = fullyPopulated(randomUUID().toString());
+
+        final ChunkedEntry copy = original.toBuilder().build();
+
+        assertEquals(original, copy);
+    }
+
+    @Test
+    @DisplayName("toBuilder().clientId(...).build() changes only the clientId")
+    void shouldOverrideOnlyClientId_viaToBuilder() {
+        final ChunkedEntry original = fullyPopulated(randomUUID().toString());
+        final String newClientId = randomUUID().toString();
+
+        final ChunkedEntry overridden = original.toBuilder().clientId(newClientId).build();
+
+        assertEquals(newClientId, overridden.clientId());
+        assertEquals(original.id(), overridden.id());
+        assertEquals(original.documentId(), overridden.documentId());
+        assertEquals(original.chunk(), overridden.chunk());
+        assertEquals(original.chunkVector(), overridden.chunkVector());
+        assertEquals(original.documentFileName(), overridden.documentFileName());
+        assertEquals(original.pageNumber(), overridden.pageNumber());
+        assertEquals(original.chunkIndex(), overridden.chunkIndex());
+        assertEquals(original.documentFileUrl(), overridden.documentFileUrl());
+        assertEquals(original.customMetadata(), overridden.customMetadata());
+    }
+
+    private ChunkedEntry fullyPopulated(final String clientId) {
+        return ChunkedEntry.builder()
+                .id(randomUUID().toString())
+                .documentId(randomUUID().toString())
+                .chunk("some content")
+                .chunkVector(List.of(0.1f, 0.2f, 0.3f))
+                .documentFileName("file.pdf")
+                .pageNumber(1)
+                .chunkIndex(0)
+                .documentFileUrl("https://storage/file.pdf")
+                .customMetadata(List.of(new KeyValuePair("key", "value")))
+                .clientId(clientId)
+                .build();
+    }
+
+    @Test
     @DisplayName("legacy JSON without a clientId property deserialises with clientId == null")
     void shouldDeserialiseLegacyJsonWithNullClientId() throws Exception {
         final String legacyJson = """

--- a/ai-document-status-check-function/src/main/java/uk/gov/moj/cp/azure/status/check/DocumentStatusByReferenceFunction.java
+++ b/ai-document-status-check-function/src/main/java/uk/gov/moj/cp/azure/status/check/DocumentStatusByReferenceFunction.java
@@ -49,10 +49,6 @@ public class DocumentStatusByReferenceFunction {
         this.clientIdentityResolver = HeaderClientIdentityResolver.fromEnvironment();
     }
 
-    public DocumentStatusByReferenceFunction(final DocumentIngestionOutcomeTableService documentIngestionOutcomeTableService) {
-        this(documentIngestionOutcomeTableService, null);
-    }
-
     public DocumentStatusByReferenceFunction(final DocumentIngestionOutcomeTableService documentIngestionOutcomeTableService,
                                              final ClientIdentityResolver clientIdentityResolver) {
         this.documentIngestionOutcomeTableService = documentIngestionOutcomeTableService;

--- a/ai-document-status-check-function/src/test/java/uk/gov/moj/cp/azure/status/check/DocumentStatusByReferenceFunctionClientIdentityTest.java
+++ b/ai-document-status-check-function/src/test/java/uk/gov/moj/cp/azure/status/check/DocumentStatusByReferenceFunctionClientIdentityTest.java
@@ -102,7 +102,7 @@ class DocumentStatusByReferenceFunctionClientIdentityTest {
     @DisplayName("flag off (default resolver) keeps the legacy null-scoped lookup")
     void shouldUseLegacyLookup_whenEnforcementOff() throws Exception {
         final String reference = randomUUID().toString();
-        final DocumentStatusByReferenceFunction defaultFunction = new DocumentStatusByReferenceFunction(tableService);
+        final DocumentStatusByReferenceFunction defaultFunction = new DocumentStatusByReferenceFunction(tableService, null);
 
         defaultFunction.run(request, reference, context);
 

--- a/ai-document-status-check-function/src/test/java/uk/gov/moj/cp/azure/status/check/DocumentStatusByReferenceFunctionTest.java
+++ b/ai-document-status-check-function/src/test/java/uk/gov/moj/cp/azure/status/check/DocumentStatusByReferenceFunctionTest.java
@@ -47,7 +47,7 @@ class DocumentStatusByReferenceFunctionTest {
 
     @BeforeEach
     void setUp() {
-        function = new DocumentStatusByReferenceFunction(documentIngestionOutcomeTableService);
+        function = new DocumentStatusByReferenceFunction(documentIngestionOutcomeTableService, null);
 
         when(request.createResponseBuilder(any(HttpStatus.class))).thenReturn(responseBuilder);
         when(responseBuilder.header(anyString(), anyString())).thenReturn(responseBuilder);


### PR DESCRIPTION
**Jira:** DD-42722

Follow-up actioning the post-merge review comments on PR #120, plus the related builder hardening.

## Changes

- **Shared payload-clientId validator** — the two identical private `validatedClientId` methods in the queue workers are replaced by `ClientId.requireValidOrNull` in shared artefacts (legacy null/empty stays null; a present value is validated as a UUID).
- **Claim-block simplification** in `AnswerGenerationFunction` — the double `clientId`/`claimClientId` assignment collapses to one validation call. (The `validPayload` alias remains: `payload` is reassigned during parsing, so it is not effectively final and cannot be captured by the `runOnce` lambda.)
- **Bridge constructors removed** from the five HTTP functions — the pre-existing test-seam arity that delegated with a null resolver is gone; test call sites use the full-arity constructor, whose null-resolver fallback to `HeaderClientIdentityResolver.fromEnvironment()` gives identical semantics.
- **`ChunkedEntry.toBuilder()`** — returns a builder pre-populated with all fields; the two copy-with-override sites (embedding enrichment, migration index copier) now use it instead of field-by-field rebuilds. This closes the bug class that has occurred twice (a rebuild silently dropping a newly added field — most recently the client id being stripped from indexed chunks, caught by the enforcement-on integration suite in PR #121).

## Review-comment mapping (PR #120)

| Comment | Addressed by |
|---|---|
| `AnswerGenerationFunction` — "can this be simplified?" | claim-block simplification |
| `DocumentIngestionFunction` — "same method… move to util class?" | `ClientId.requireValidOrNull` |
| 5 × "can this constructor be removed?" | bridge constructors removed |

## Verification

- Unit tests green across all six touched modules (shared-artefacts 258 (+7), metadata-check 56, ingestion 70, answer-retrieval 183, status-check 8, migration-tool 62).
- Whole-reactor `mvn clean test-compile` green (harness-eval module included).
- Behaviour-preserving: no production semantics change; the new tests cover `requireValidOrNull` and the `toBuilder()` round trip.