### PR TITLE
Extract citation-metric logic into stateless CitationMetrics + unit tests

### DIFF
--- a/ai-document-system-prompt-harness-eval/src/main/java/uk/gov/moj/cp/harness/CitationMetrics.java
+++ b/ai-document-system-prompt-harness-eval/src/main/java/uk/gov/moj/cp/harness/CitationMetrics.java
@@ -1,0 +1,247 @@
+package uk.gov.moj.cp.harness;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import uk.gov.moj.cp.retrieval.model.LlmResponse;
+import uk.gov.moj.cp.retrieval.service.CitationProcessor;
+
+/**
+ * Pure, stateless derivation of citation-format compliance metrics from a single LLM response —
+ * the numbers every evaluation report headlines (prose length, cited pages, rendered/stripped
+ * citations, same-document stacking, "substantive but uncited").
+ *
+ * <p>Extracted from {@link TestHarness} so this logic is unit-testable without the harness's
+ * env-bound static initialisation. It performs no environment access and no I/O:
+ * {@link CitationProcessor} is deterministic in-process string processing, so {@link #compute}
+ * is a pure function of its input.
+ */
+final class CitationMetrics {
+
+    /** Words of prose at/above which an answer counts as substantive (refusals are far shorter). */
+    static final int SUBSTANTIVE_PROSE_WORDS = 50;
+
+    private static final CitationProcessor OUTCOME_PROCESSOR = new CitationProcessor();
+
+    private static final Pattern BARE_BRACKET = Pattern.compile("\\[(\\d+)\\]");
+    // Bounded repetition ({0,N}) on the negated classes: citation markers and page lists are short,
+    // and a bounded quantifier cannot backtrack super-linearly — this satisfies SonarQube's S5852
+    // (regex-DoS) check, which a possessive quantifier did not.
+    // Includes labelled forms ([Source 1], [Ref 2] …) that CitationProcessor's tolerant regex
+    // substitutes but a digit-first pattern would miss (observed blind spot).
+    private static final Pattern ANY_BRACKET_CITATION = Pattern.compile(
+            "(?i)\\[\\^?(?:(?:Source|doc|Citation|Ref)[\\s:]{1,3})?\\d[^\\[\\]]{0,40}\\]");
+    /** Any bracketed token — used to strip all citation markers when measuring prose length. */
+    private static final Pattern BRACKET_TOKEN = Pattern.compile("\\[[^\\[\\]]{0,64}\\]");
+    private static final Pattern JSON_CITATION_ID = Pattern.compile("\"citationId\"\\s*:\\s*(\\d+)");
+    /** Captures each individualPageNumbers value, to count how many source pages the answer cites. */
+    private static final Pattern INDIVIDUAL_PAGES = Pattern.compile("\"individualPageNumbers\"\\s*:\\s*\"([^\"]{0,200})\"");
+    /** A maximal run of >=2 adjacent bare [N] markers, separated by at most a few horizontal
+     *  whitespace chars. Every quantifier is bounded and each repetition is anchored on a literal
+     *  '[' — no super-linear backtracking (S5852). */
+    private static final Pattern MARKER_RUN = Pattern.compile("\\[\\d{1,4}\\](?:[ \\t]{0,3}\\[\\d{1,4}\\]){1,50}");
+    /** One JSON object literal inside a FACT_MAP_JSON payload (objects are flat — no nesting). */
+    private static final Pattern JSON_OBJECT = Pattern.compile("\\{[^{}]{0,600}\\}");
+    /** Quote-tolerant citationId, for the id→documentId map: models emit both 1 and "1". */
+    private static final Pattern OBJ_CITATION_ID = Pattern.compile("\"citationId\"\\s*:\\s*\"?(\\d{1,6})\"?");
+    private static final Pattern OBJ_DOCUMENT_ID = Pattern.compile("\"documentId\"\\s*:\\s*\"([^\"]{0,80})\"");
+    /** Literal citation-block tags (the prompt mandates these exact tags). Matched case-insensitively
+     *  by index scan rather than a regex, to avoid any backtracking over the block body. */
+    private static final String FACT_MAP_OPEN = "<FACT_MAP_JSON>";
+    private static final String FACT_MAP_CLOSE = "</FACT_MAP_JSON>";
+
+    private CitationMetrics() {
+    }
+
+    /**
+     * Citation-format compliance metrics for one response. {@code rawInlineMarkers}/{@code inlineIds}
+     * are the bare {@code [N]} markers; {@code rawDriftMarkers} is the excess of any-bracket-citation
+     * matches over bare ones; {@code jsonEntries}/{@code jsonIds} come from the FACT_MAP_JSON block;
+     * {@code proseChars}/{@code proseWords} measure the narrative with the JSON block and every inline
+     * bracket marker removed, so verbosity is comparable across models independently of citation count.
+     */
+    record Compliance(int rawInlineMarkers, Set<Integer> inlineIds, int rawDriftMarkers,
+                      int jsonEntries, Set<Integer> jsonIds,
+                      boolean inlineSubsetOfJson, boolean processorSubstituted,
+                      boolean jsonBlockPresent, int proseChars, int proseWords, int citedPages,
+                      int sameDocStackedRuns, int renderedCitations, int strippedMarkers,
+                      boolean uncitedSubstantive) {
+    }
+
+    /**
+     * Extract citation-format compliance metrics from one LLM response. Compares:
+     * inline {@code [N]} markers (bare) vs any-bracket-citation matches (difference = drift),
+     * JSON citationId values, whether every inline id appears in the JSON, whether
+     * {@link CitationProcessor} actually substituted, and whether a parseable JSON block exists.
+     */
+    static Compliance compute(final LlmResponse response) {
+        final String raw = response.rawLlmResponse() == null ? "" : response.rawLlmResponse();
+        final String formatted = response.formattedLlmResponse() == null ? "" : response.formattedLlmResponse();
+
+        final boolean jsonBlockPresent = hasFactMapBlock(raw);
+
+        // Strip the FACT_MAP_JSON block(s) before counting inline markers — example
+        // placeholders inside the JSON should not pollute the inline-marker count.
+        final String rawWithoutJson = stripFactMapBlocks(raw);
+
+        final Set<Integer> inlineIds = new TreeSet<>();
+        int bareCount = 0;
+        final Matcher bare = BARE_BRACKET.matcher(rawWithoutJson);
+        while (bare.find()) {
+            bareCount++;
+            inlineIds.add(Integer.parseInt(bare.group(1)));
+        }
+        int anyCount = 0;
+        final Matcher any = ANY_BRACKET_CITATION.matcher(rawWithoutJson);
+        while (any.find()) {
+            anyCount++;
+        }
+        final int driftCount = Math.max(0, anyCount - bareCount);
+
+        final Set<Integer> jsonIds = new TreeSet<>();
+        int jsonEntryCount = 0;
+        final Matcher json = JSON_CITATION_ID.matcher(raw);
+        while (json.find()) {
+            jsonEntryCount++;
+            jsonIds.add(Integer.parseInt(json.group(1)));
+        }
+
+        final boolean inlineSubsetOfJson = !inlineIds.isEmpty() && jsonIds.containsAll(inlineIds);
+        final boolean processorSubstituted = formatted.contains("::(Source");
+
+        // Prose-only length: drop every bracket citation marker from the JSON-stripped
+        // text and collapse whitespace, so the count reflects the narrative alone.
+        final String prose = BRACKET_TOKEN.matcher(rawWithoutJson).replaceAll("")
+                .replaceAll("\\s+", " ").trim();
+        final int proseChars = prose.length();
+        final int proseWords = prose.isEmpty() ? 0 : prose.split(" ").length;
+
+        // Coverage proxy: total source pages cited across all JSON entries. Watched alongside
+        // proseWords so we can tell padding-removal (words down, pages flat) from fact-loss
+        // (words down, pages down) when tuning length.
+        int citedPages = 0;
+        final Matcher pagesMatcher = INDIVIDUAL_PAGES.matcher(raw);
+        while (pagesMatcher.find()) {
+            for (final String tok : pagesMatcher.group(1).split(",")) {
+                if (!tok.trim().isEmpty()) {
+                    citedPages++;
+                }
+            }
+        }
+
+        final int sameDocStackedRuns =
+                countSameDocStackedRuns(rawWithoutJson, buildCitationIdToDocumentId(raw));
+
+        // Same signal the production citation guard consumes: rendered/stripped counts and the
+        // "substantive but uncited" flag (legitimate short refusals stay below the word floor).
+        final CitationProcessor.CitationOutcome outcome = OUTCOME_PROCESSOR.processCitations(raw);
+        final boolean uncitedSubstantive =
+                proseWords >= SUBSTANTIVE_PROSE_WORDS && outcome.renderedCitations() == 0;
+
+        return new Compliance(bareCount, inlineIds, driftCount, jsonEntryCount, jsonIds,
+                inlineSubsetOfJson, processorSubstituted, jsonBlockPresent, proseChars, proseWords, citedPages,
+                sameDocStackedRuns, outcome.renderedCitations(), outcome.strippedMarkers(), uncitedSubstantive);
+    }
+
+    /**
+     * Maps citationId → documentId from every object literal inside the FACT_MAP_JSON block(s),
+     * located by the same index scan as {@link #stripFactMapBlocks} (no regex over the full
+     * response). First mapping wins; quote-tolerant on the citationId.
+     */
+    private static Map<Integer, String> buildCitationIdToDocumentId(final String raw) {
+        final Map<Integer, String> idToDoc = new LinkedHashMap<>();
+        final String open = FACT_MAP_OPEN.toLowerCase(Locale.ROOT);
+        final String close = FACT_MAP_CLOSE.toLowerCase(Locale.ROOT);
+        final String lower = raw.toLowerCase(Locale.ROOT);
+        int from = 0;
+        while (true) {
+            final int o = lower.indexOf(open, from);
+            final int c = o < 0 ? -1 : lower.indexOf(close, o + open.length());
+            if (o < 0 || c < 0) {
+                return idToDoc;
+            }
+            final Matcher obj = JSON_OBJECT.matcher(raw.substring(o + open.length(), c));
+            while (obj.find()) {
+                addObjectMapping(obj.group(), idToDoc);
+            }
+            from = c + close.length();
+        }
+    }
+
+    private static void addObjectMapping(final String objectLiteral, final Map<Integer, String> idToDoc) {
+        final Matcher id = OBJ_CITATION_ID.matcher(objectLiteral);
+        final Matcher doc = OBJ_DOCUMENT_ID.matcher(objectLiteral);
+        if (id.find() && doc.find()) {
+            idToDoc.putIfAbsent(Integer.parseInt(id.group(1)), doc.group(1));
+        }
+    }
+
+    /**
+     * Counts maximal adjacent {@code [N][M]…} runs in the raw answer where at least two
+     * CONSECUTIVE ids resolve to the same documentId — the "same-document stacking" the
+     * prompt tells the model to merge into a single citation entry. Adjacent ids from
+     * different documents (legitimate multi-document support) do not count.
+     */
+    private static int countSameDocStackedRuns(final String rawWithoutJson, final Map<Integer, String> idToDoc) {
+        int stackedRuns = 0;
+        final Matcher run = MARKER_RUN.matcher(rawWithoutJson);
+        while (run.find()) {
+            if (runHasSameDocAdjacency(run.group(), idToDoc)) {
+                stackedRuns++;
+            }
+        }
+        return stackedRuns;
+    }
+
+    private static boolean runHasSameDocAdjacency(final String runText, final Map<Integer, String> idToDoc) {
+        String prevDoc = null;
+        final Matcher m = BARE_BRACKET.matcher(runText);
+        while (m.find()) {
+            final String doc = idToDoc.get(Integer.parseInt(m.group(1)));
+            if (doc != null && doc.equals(prevDoc)) {
+                return true;
+            }
+            prevDoc = doc;
+        }
+        return false;
+    }
+
+    /** True if {@code raw} contains a complete (open … close) FACT_MAP_JSON block, case-insensitively. */
+    private static boolean hasFactMapBlock(final String raw) {
+        final String lower = raw.toLowerCase(Locale.ROOT);
+        final int open = lower.indexOf(FACT_MAP_OPEN.toLowerCase(Locale.ROOT));
+        return open >= 0 && lower.indexOf(FACT_MAP_CLOSE.toLowerCase(Locale.ROOT), open + FACT_MAP_OPEN.length()) >= 0;
+    }
+
+    /**
+     * Returns {@code raw} with every complete FACT_MAP_JSON block removed via an index scan (no regex
+     * backtracking), so example placeholders inside the JSON don't pollute the inline-marker count.
+     */
+    private static String stripFactMapBlocks(final String raw) {
+        final String open = FACT_MAP_OPEN.toLowerCase(Locale.ROOT);
+        final String close = FACT_MAP_CLOSE.toLowerCase(Locale.ROOT);
+        final String lower = raw.toLowerCase(Locale.ROOT);
+        final StringBuilder out = new StringBuilder();
+        int from = 0;
+        while (true) {
+            final int o = lower.indexOf(open, from);
+            final int c = o < 0 ? -1 : lower.indexOf(close, o + open.length());
+            if (o < 0 || c < 0) {
+                return out.append(raw, from, raw.length()).toString();
+            }
+            out.append(raw, from, o);
+            from = c + close.length();
+        }
+    }
+
+    /** Citation-stripped prose of a raw response: FACT_MAP block(s) and every bracket token removed. */
+    static String proseOf(final String raw) {
+        final String withoutJson = stripFactMapBlocks(raw == null ? "" : raw);
+        return BRACKET_TOKEN.matcher(withoutJson).replaceAll("").replaceAll("\\s+", " ").trim();
+    }
+}

--- a/ai-document-system-prompt-harness-eval/src/main/java/uk/gov/moj/cp/harness/ResponseQualityComparator.java
+++ b/ai-document-system-prompt-harness-eval/src/main/java/uk/gov/moj/cp/harness/ResponseQualityComparator.java
@@ -352,7 +352,7 @@ final class ResponseQualityComparator {
         if (cache.containsKey(cacheKey)) {
             return cache.get(cacheKey);
         }
-        final String prose = TestHarness.proseOf(r.response().rawLlmResponse());
+        final String prose = CitationMetrics.proseOf(r.response().rawLlmResponse());
         final List<Float> vector = prose.isEmpty() ? null : embeddingService.embedData(prose);
         cache.put(cacheKey, vector);
         return vector;

--- a/ai-document-system-prompt-harness-eval/src/main/java/uk/gov/moj/cp/harness/TestHarness.java
+++ b/ai-document-system-prompt-harness-eval/src/main/java/uk/gov/moj/cp/harness/TestHarness.java
@@ -34,14 +34,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,7 +74,7 @@ import org.slf4j.LoggerFactory;
  *       on reasoning models from ordinary citation mismatches), {@code match} (every inline
  *       {@code [N]} resolves to a JSON entry), {@code subst} (the processor substituted a
  *       source), prose length (verbosity, citation-independent) and cited-page count
- *       (coverage). See {@link Compliance} and the legend in {@link #printConsistency}.</li>
+ *       (coverage). See {@link CitationMetrics.Compliance} and the legend in {@link #printConsistency}.</li>
  * </ul>
  *
  * <p><b>Running.</b> This is a {@code main()} tool, not a unit test, because it makes
@@ -162,33 +158,12 @@ public final class TestHarness {
     }
 
     /**
-     * Citation-format compliance metrics derived from a single LLM response.
-     *
-     * <p>{@code proseChars}/{@code proseWords} measure the narrative answer ONLY —
-     * the raw response with the {@code <FACT_MAP_JSON>} block and every inline
-     * bracket marker removed — so verbosity can be compared across models
-     * independently of how many citations each emitted.
+     * {@link CitationMetrics.Compliance} per response, computed once. The summary, consistency and
+     * detail sections all need the same metrics; recomputing would also re-run the citation
+     * processor, whose INFO lines would then spam every report section. Reporting is single-threaded
+     * (post-join), so a plain identity map suffices.
      */
-    record Compliance(int rawInlineMarkers, Set<Integer> inlineIds, int rawDriftMarkers,
-                      int jsonEntries, Set<Integer> jsonIds,
-                      boolean inlineSubsetOfJson, boolean processorSubstituted,
-                      boolean jsonBlockPresent, int proseChars, int proseWords, int citedPages,
-                      int sameDocStackedRuns, int renderedCitations, int strippedMarkers,
-                      boolean uncitedSubstantive) {
-    }
-
-    /** Words of prose at/above which an answer counts as substantive (refusals are far shorter). */
-    private static final int SUBSTANTIVE_PROSE_WORDS = 50;
-
-    private static final CitationProcessor OUTCOME_PROCESSOR = new CitationProcessor();
-
-    /**
-     * Compliance per response, computed once. The summary, consistency and detail sections all
-     * need the same metrics; recomputing would also re-run {@link CitationProcessor}, whose INFO
-     * lines would then spam every report section. Reporting is single-threaded (post-join), so a
-     * plain identity map suffices.
-     */
-    private static final Map<LlmResponse, Compliance> COMPLIANCE_BY_RESPONSE = new IdentityHashMap<>();
+    private static final Map<LlmResponse, CitationMetrics.Compliance> COMPLIANCE_BY_RESPONSE = new IdentityHashMap<>();
 
     public static void main(final String[] args) throws InterruptedException {
         final List<SystemPromptConfig> systemPrompts = loadPrompts();
@@ -562,7 +537,7 @@ public final class TestHarness {
                 "iter", "query", "prompt", "llm", "status", "ms", "chars", "prose", "words"));
         LOGGER.info("-".repeat(160));
         for (final RunResult r : results) {
-            final Compliance c = r.response() != null ? computeCompliance(r.response()) : null;
+            final CitationMetrics.Compliance c = r.response() != null ? computeCompliance(r.response()) : null;
             LOGGER.info(String.format("%4d | %-26s | %-26s | %-22s | %6s | %6d | %6d | %6d | %6d",
                     r.iteration(),
                     truncate(r.queryLabel(), 26),
@@ -640,7 +615,7 @@ public final class TestHarness {
             }
             ok++;
             msSum += r.durationMs();
-            final Compliance c = computeCompliance(r.response());
+            final CitationMetrics.Compliance c = computeCompliance(r.response());
             jsonPresent += c.jsonBlockPresent() ? 1 : 0;
             matched += c.inlineSubsetOfJson() ? 1 : 0;
             substituted += c.processorSubstituted() ? 1 : 0;
@@ -675,211 +650,16 @@ public final class TestHarness {
         LOGGER.info("             to the SAME documentId — should be 0; the prompt requires one merged citation");
         LOGGER.info("             (adjacent markers for DIFFERENT documents are legitimate and not counted)");
         LOGGER.info("  msAvg    = mean generation latency (ms) across the cell's OK runs — model speed at a glance");
-        LOGGER.info("  uncited  = substantive answers (>= " + SUBSTANTIVE_PROSE_WORDS + " prose words) with ZERO rendered citations —");
+        LOGGER.info("  uncited  = substantive answers (>= " + CitationMetrics.SUBSTANTIVE_PROSE_WORDS + " prose words) with ZERO rendered citations —");
         LOGGER.info("             the citation guard's rejection signal; legitimate short refusals do not count");
     }
 
-    private static final Pattern BARE_BRACKET = Pattern.compile("\\[(\\d+)\\]");
-    // Bounded repetition ({0,N}) on the negated classes: citation markers and page lists are short,
-    // and a bounded quantifier cannot backtrack super-linearly — this satisfies SonarQube's S5852
-    // (regex-DoS) check, which a possessive quantifier did not.
-    // Includes labelled forms ([Source 1], [Ref 2] …) that CitationProcessor's tolerant regex
-    // substitutes but a digit-first pattern would miss (observed blind spot).
-    private static final Pattern ANY_BRACKET_CITATION = Pattern.compile(
-            "(?i)\\[\\^?(?:(?:Source|doc|Citation|Ref)[\\s:]{1,3})?\\d[^\\[\\]]{0,40}\\]");
-    /** Any bracketed token — used to strip all citation markers when measuring prose length. */
-    private static final Pattern BRACKET_TOKEN = Pattern.compile("\\[[^\\[\\]]{0,64}\\]");
-    private static final Pattern JSON_CITATION_ID = Pattern.compile("\"citationId\"\\s*:\\s*(\\d+)");
-    /** Captures each individualPageNumbers value, to count how many source pages the answer cites. */
-    private static final Pattern INDIVIDUAL_PAGES = Pattern.compile("\"individualPageNumbers\"\\s*:\\s*\"([^\"]{0,200})\"");
-    /** A maximal run of >=2 adjacent bare [N] markers, separated by at most a few horizontal
-     *  whitespace chars. Every quantifier is bounded and each repetition is anchored on a literal
-     *  '[' — no super-linear backtracking (S5852). */
-    private static final Pattern MARKER_RUN = Pattern.compile("\\[\\d{1,4}\\](?:[ \\t]{0,3}\\[\\d{1,4}\\]){1,50}");
-    /** One JSON object literal inside a FACT_MAP_JSON payload (objects are flat — no nesting). */
-    private static final Pattern JSON_OBJECT = Pattern.compile("\\{[^{}]{0,600}\\}");
-    /** Quote-tolerant citationId, for the id→documentId map: models emit both 1 and "1". */
-    private static final Pattern OBJ_CITATION_ID = Pattern.compile("\"citationId\"\\s*:\\s*\"?(\\d{1,6})\"?");
-    private static final Pattern OBJ_DOCUMENT_ID = Pattern.compile("\"documentId\"\\s*:\\s*\"([^\"]{0,80})\"");
-    /** Literal citation-block tags (the prompt mandates these exact tags). Matched case-insensitively
-     *  by index scan rather than a regex, to avoid any backtracking over the block body. */
-    private static final String FACT_MAP_OPEN = "<FACT_MAP_JSON>";
-    private static final String FACT_MAP_CLOSE = "</FACT_MAP_JSON>";
-
     /**
-     * Extract citation-format compliance metrics from one LLM response. Compares:
-     * inline {@code [N]} markers (bare) vs any-bracket-citation matches (difference = drift),
-     * JSON citationId values, whether every inline id appears in the JSON, whether
-     * {@link CitationProcessor} actually substituted, and whether a parseable JSON block exists.
+     * Citation-format compliance metrics for one response, memoised per response so the summary,
+     * consistency and detail sections share a single {@link CitationMetrics#compute} pass.
      */
-    private static Compliance computeCompliance(final LlmResponse response) {
-        return COMPLIANCE_BY_RESPONSE.computeIfAbsent(response, TestHarness::computeComplianceUncached);
-    }
-
-    private static Compliance computeComplianceUncached(final LlmResponse response) {
-        final String raw = response.rawLlmResponse() == null ? "" : response.rawLlmResponse();
-        final String formatted = response.formattedLlmResponse() == null ? "" : response.formattedLlmResponse();
-
-        final boolean jsonBlockPresent = hasFactMapBlock(raw);
-
-        // Strip the FACT_MAP_JSON block(s) before counting inline markers — example
-        // placeholders inside the JSON should not pollute the inline-marker count.
-        final String rawWithoutJson = stripFactMapBlocks(raw);
-
-        final Set<Integer> inlineIds = new TreeSet<>();
-        int bareCount = 0;
-        final Matcher bare = BARE_BRACKET.matcher(rawWithoutJson);
-        while (bare.find()) {
-            bareCount++;
-            inlineIds.add(Integer.parseInt(bare.group(1)));
-        }
-        int anyCount = 0;
-        final Matcher any = ANY_BRACKET_CITATION.matcher(rawWithoutJson);
-        while (any.find()) {
-            anyCount++;
-        }
-        final int driftCount = Math.max(0, anyCount - bareCount);
-
-        final Set<Integer> jsonIds = new TreeSet<>();
-        int jsonEntryCount = 0;
-        final Matcher json = JSON_CITATION_ID.matcher(raw);
-        while (json.find()) {
-            jsonEntryCount++;
-            jsonIds.add(Integer.parseInt(json.group(1)));
-        }
-
-        final boolean inlineSubsetOfJson = !inlineIds.isEmpty() && jsonIds.containsAll(inlineIds);
-        final boolean processorSubstituted = formatted.contains("::(Source");
-
-        // Prose-only length: drop every bracket citation marker from the JSON-stripped
-        // text and collapse whitespace, so the count reflects the narrative alone.
-        final String prose = BRACKET_TOKEN.matcher(rawWithoutJson).replaceAll("")
-                .replaceAll("\\s+", " ").trim();
-        final int proseChars = prose.length();
-        final int proseWords = prose.isEmpty() ? 0 : prose.split(" ").length;
-
-        // Coverage proxy: total source pages cited across all JSON entries. Watched alongside
-        // proseWords so we can tell padding-removal (words down, pages flat) from fact-loss
-        // (words down, pages down) when tuning length.
-        int citedPages = 0;
-        final Matcher pagesMatcher = INDIVIDUAL_PAGES.matcher(raw);
-        while (pagesMatcher.find()) {
-            for (final String tok : pagesMatcher.group(1).split(",")) {
-                if (!tok.trim().isEmpty()) {
-                    citedPages++;
-                }
-            }
-        }
-
-        final int sameDocStackedRuns =
-                countSameDocStackedRuns(rawWithoutJson, buildCitationIdToDocumentId(raw));
-
-        // Same signal the production citation guard consumes: rendered/stripped counts and the
-        // "substantive but uncited" flag (legitimate short refusals stay below the word floor).
-        final CitationProcessor.CitationOutcome outcome = OUTCOME_PROCESSOR.processCitations(raw);
-        final boolean uncitedSubstantive =
-                proseWords >= SUBSTANTIVE_PROSE_WORDS && outcome.renderedCitations() == 0;
-
-        return new Compliance(bareCount, inlineIds, driftCount, jsonEntryCount, jsonIds,
-                inlineSubsetOfJson, processorSubstituted, jsonBlockPresent, proseChars, proseWords, citedPages,
-                sameDocStackedRuns, outcome.renderedCitations(), outcome.strippedMarkers(), uncitedSubstantive);
-    }
-
-    /**
-     * Maps citationId → documentId from every object literal inside the FACT_MAP_JSON block(s),
-     * located by the same index scan as {@link #stripFactMapBlocks} (no regex over the full
-     * response). First mapping wins; quote-tolerant on the citationId.
-     */
-    private static Map<Integer, String> buildCitationIdToDocumentId(final String raw) {
-        final Map<Integer, String> idToDoc = new LinkedHashMap<>();
-        final String open = FACT_MAP_OPEN.toLowerCase(Locale.ROOT);
-        final String close = FACT_MAP_CLOSE.toLowerCase(Locale.ROOT);
-        final String lower = raw.toLowerCase(Locale.ROOT);
-        int from = 0;
-        while (true) {
-            final int o = lower.indexOf(open, from);
-            final int c = o < 0 ? -1 : lower.indexOf(close, o + open.length());
-            if (o < 0 || c < 0) {
-                return idToDoc;
-            }
-            final Matcher obj = JSON_OBJECT.matcher(raw.substring(o + open.length(), c));
-            while (obj.find()) {
-                addObjectMapping(obj.group(), idToDoc);
-            }
-            from = c + close.length();
-        }
-    }
-
-    private static void addObjectMapping(final String objectLiteral, final Map<Integer, String> idToDoc) {
-        final Matcher id = OBJ_CITATION_ID.matcher(objectLiteral);
-        final Matcher doc = OBJ_DOCUMENT_ID.matcher(objectLiteral);
-        if (id.find() && doc.find()) {
-            idToDoc.putIfAbsent(Integer.parseInt(id.group(1)), doc.group(1));
-        }
-    }
-
-    /**
-     * Counts maximal adjacent {@code [N][M]…} runs in the raw answer where at least two
-     * CONSECUTIVE ids resolve to the same documentId — the "same-document stacking" the
-     * prompt tells the model to merge into a single citation entry. Adjacent ids from
-     * different documents (legitimate multi-document support) do not count.
-     */
-    private static int countSameDocStackedRuns(final String rawWithoutJson, final Map<Integer, String> idToDoc) {
-        int stackedRuns = 0;
-        final Matcher run = MARKER_RUN.matcher(rawWithoutJson);
-        while (run.find()) {
-            if (runHasSameDocAdjacency(run.group(), idToDoc)) {
-                stackedRuns++;
-            }
-        }
-        return stackedRuns;
-    }
-
-    private static boolean runHasSameDocAdjacency(final String runText, final Map<Integer, String> idToDoc) {
-        String prevDoc = null;
-        final Matcher m = BARE_BRACKET.matcher(runText);
-        while (m.find()) {
-            final String doc = idToDoc.get(Integer.parseInt(m.group(1)));
-            if (doc != null && doc.equals(prevDoc)) {
-                return true;
-            }
-            prevDoc = doc;
-        }
-        return false;
-    }
-
-    /** True if {@code raw} contains a complete (open … close) FACT_MAP_JSON block, case-insensitively. */
-    private static boolean hasFactMapBlock(final String raw) {
-        final String lower = raw.toLowerCase(Locale.ROOT);
-        final int open = lower.indexOf(FACT_MAP_OPEN.toLowerCase(Locale.ROOT));
-        return open >= 0 && lower.indexOf(FACT_MAP_CLOSE.toLowerCase(Locale.ROOT), open + FACT_MAP_OPEN.length()) >= 0;
-    }
-
-    /**
-     * Returns {@code raw} with every complete FACT_MAP_JSON block removed via an index scan (no regex
-     * backtracking), so example placeholders inside the JSON don't pollute the inline-marker count.
-     */
-    private static String stripFactMapBlocks(final String raw) {
-        final String open = FACT_MAP_OPEN.toLowerCase(Locale.ROOT);
-        final String close = FACT_MAP_CLOSE.toLowerCase(Locale.ROOT);
-        final String lower = raw.toLowerCase(Locale.ROOT);
-        final StringBuilder out = new StringBuilder();
-        int from = 0;
-        while (true) {
-            final int o = lower.indexOf(open, from);
-            final int c = o < 0 ? -1 : lower.indexOf(close, o + open.length());
-            if (o < 0 || c < 0) {
-                return out.append(raw, from, raw.length()).toString();
-            }
-            out.append(raw, from, o);
-            from = c + close.length();
-        }
-    }
-
-    /** Citation-stripped prose of a raw response: FACT_MAP block(s) and every bracket token removed. */
-    static String proseOf(final String raw) {
-        final String withoutJson = stripFactMapBlocks(raw == null ? "" : raw);
-        return BRACKET_TOKEN.matcher(withoutJson).replaceAll("").replaceAll("\\s+", " ").trim();
+    private static CitationMetrics.Compliance computeCompliance(final LlmResponse response) {
+        return COMPLIANCE_BY_RESPONSE.computeIfAbsent(response, CitationMetrics::compute);
     }
 
     /** Applies the same pre-call delay as generation calls; restores the interrupt flag if interrupted. */
@@ -930,7 +710,7 @@ public final class TestHarness {
         if (r.response() == null) {
             return;
         }
-        final Compliance c = computeCompliance(r.response());
+        final CitationMetrics.Compliance c = computeCompliance(r.response());
         LOGGER.info("status: {} | jsonBlock: {} | inlineIds: {} | jsonIds: {}"
                         + " | drift: {} | match: {} | subst: {} | proseChars: {} | proseWords: {}"
                         + " | citedPages: {} | sameDocStacks: {} | rendered: {} | stripped: {} | uncitedSubstantive: {}",

--- a/ai-document-system-prompt-harness-eval/src/test/java/uk/gov/moj/cp/harness/CitationMetricsTest.java
+++ b/ai-document-system-prompt-harness-eval/src/test/java/uk/gov/moj/cp/harness/CitationMetricsTest.java
@@ -1,0 +1,124 @@
+package uk.gov.moj.cp.harness;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.hmcts.cp.openapi.model.AnswerGenerationStatus;
+import uk.gov.moj.cp.harness.CitationMetrics.Compliance;
+import uk.gov.moj.cp.retrieval.model.LlmResponse;
+
+/**
+ * Unit tests for {@link CitationMetrics} — the derivation of the citation/verbosity metrics that
+ * every evaluation report headlines. Uses the real (deterministic) CitationProcessor via
+ * {@link CitationMetrics#compute}; no environment access or network I/O is involved.
+ */
+class CitationMetricsTest {
+
+    private static Compliance compute(final String raw, final String formatted) {
+        return CitationMetrics.compute(new LlmResponse(raw, formatted, AnswerGenerationStatus.ANSWER_GENERATED));
+    }
+
+    /** A FACT_MAP_JSON block wrapping the given flat object literals. */
+    private static String factMap(final String... objects) {
+        return "\n\n<FACT_MAP_JSON>[" + String.join(",", objects) + "]</FACT_MAP_JSON>";
+    }
+
+    private static String obj(final int id, final String documentId, final String pages) {
+        return "{\"citationId\":" + id + ",\"documentFilename\":\"f.pdf\",\"individualPageNumbers\":\""
+                + pages + "\",\"documentId\":\"" + documentId + "\"}";
+    }
+
+    @Test
+    void compute_wellFormedAnswer_reportsMarkersJsonAndPages() {
+        final String raw = "The defendant assaulted the victim [1]. He later fled the scene [2]."
+                + factMap(obj(1, "doc-A", "3,4"), obj(2, "doc-A", "5"));
+        final Compliance c = compute(raw, "formatted ::(Source: [f.pdf], Pages 3)");
+
+        assertTrue(c.jsonBlockPresent());
+        assertEquals(2, c.rawInlineMarkers());
+        assertEquals(Set.of(1, 2), c.inlineIds());
+        assertEquals(2, c.jsonEntries());
+        assertEquals(Set.of(1, 2), c.jsonIds());
+        assertTrue(c.inlineSubsetOfJson(), "every inline id appears in the JSON");
+        assertEquals(3, c.citedPages(), "pages 3,4 + 5");
+        assertEquals(0, c.sameDocStackedRuns(), "markers are not adjacent");
+        assertEquals(0, c.strippedMarkers());
+        assertTrue(c.renderedCitations() >= 1);
+        assertTrue(c.processorSubstituted());
+        assertFalse(c.uncitedSubstantive(), "short answer, and it is cited");
+    }
+
+    @Test
+    void compute_longAnswerWithNoCitations_isUncitedSubstantive() {
+        final String raw = ("fact ".repeat(60)).trim();   // 60 prose words, no markers, no JSON
+        final Compliance c = compute(raw, "");
+
+        assertFalse(c.jsonBlockPresent());
+        assertEquals(0, c.rawInlineMarkers());
+        assertTrue(c.inlineIds().isEmpty());
+        assertEquals(0, c.jsonEntries());
+        assertEquals(0, c.citedPages());
+        assertEquals(0, c.renderedCitations());
+        assertTrue(c.proseWords() >= 50);
+        assertTrue(c.uncitedSubstantive(), "substantive prose with zero rendered citations");
+    }
+
+    @Test
+    void compute_shortRefusal_isNotUncited() {
+        final Compliance c = compute("No relevant previous convictions found.", "");
+        assertEquals(0, c.renderedCitations());
+        assertTrue(c.proseWords() < CitationMetrics.SUBSTANTIVE_PROSE_WORDS);
+        assertFalse(c.uncitedSubstantive(), "below the substantive word floor");
+    }
+
+    @Test
+    void compute_adjacentMarkersSameDocument_countAsOneStackedRun() {
+        final String raw = "The victim suffered harm [1][2][3] as described."
+                + factMap(obj(1, "doc-A", "1"), obj(2, "doc-A", "2"), obj(3, "doc-A", "3"));
+        assertEquals(1, compute(raw, "").sameDocStackedRuns());
+    }
+
+    @Test
+    void compute_adjacentMarkersDifferentDocuments_doNotStack() {
+        final String raw = "Two independent sources agree [1][2] on this point."
+                + factMap(obj(1, "doc-A", "1"), obj(2, "doc-B", "2"));
+        assertEquals(0, compute(raw, "").sameDocStackedRuns(), "cross-document adjacency is legitimate");
+    }
+
+    @Test
+    void compute_inlineMarkerWithoutMatchingJson_isStrippedAndNotSubset() {
+        final String raw = "A claim [5] with no matching entry here today."
+                + factMap(obj(1, "doc-A", "1"));
+        final Compliance c = compute(raw, "");
+
+        assertFalse(c.inlineSubsetOfJson(), "inline id 5 is not in the JSON (only 1)");
+        assertTrue(c.strippedMarkers() >= 1, "unresolved [5] is stripped");
+        assertEquals(0, c.renderedCitations());
+    }
+
+    @Test
+    void compute_labelledCitation_countsAsDrift() {
+        final String raw = "See [Source 1] and also [2] for detail."
+                + factMap(obj(1, "doc-A", "1"), obj(2, "doc-A", "2"));
+        final Compliance c = compute(raw, "");
+
+        assertEquals(1, c.rawInlineMarkers(), "only [2] is a bare [N] marker");
+        assertEquals(1, c.rawDriftMarkers(), "[Source 1] is a labelled citation the bare pattern misses");
+    }
+
+    @Test
+    void proseOf_stripsFactMapBlockAndBracketMarkers() {
+        assertEquals("Hello world.", CitationMetrics.proseOf(
+                "Hello [1] world.\n<FACT_MAP_JSON>[{\"citationId\":1}]</FACT_MAP_JSON>"));
+    }
+
+    @Test
+    void proseOf_handlesNull() {
+        assertEquals("", CitationMetrics.proseOf(null));
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to the merged cross-cut PR (#126). Makes the harness's citation/verbosity **metric derivation** — the numbers every evaluation report headlines — unit-testable, and adds tests.

### Refactor
The metric logic lived in `TestHarness`, which is unreachable from a unit test: its eager `static` fields (`DOCUMENT_IDS`, `PROMPT_FILES`) require env vars at class-load, so `<clinit>` throws before any test can call a helper. This extracts the pure logic into a new stateless `CitationMetrics` class:

- `compute(LlmResponse)` + `proseOf(...)` and their FACT_MAP / regex helpers, the `Compliance` record, and the metric constants move to `CitationMetrics`.
- No environment access and no I/O — the real, deterministic `CitationProcessor` is reused, so `compute` is a pure function of its input.
- `TestHarness` delegates through its per-response cache; `ResponseQualityComparator` uses `CitationMetrics.proseOf`. Behaviour is unchanged.

### Tests
`CitationMetricsTest` (9 cases): well-formed answer (markers/JSON/pages), uncited-substantive, short-refusal word floor, same-document stacking, cross-document non-stacking, stripped unresolved marker, labelled-citation drift, and `proseOf`.

(`ResponseQualityComparatorTest`, added in #126, covers the comparator's pairing/cross-cut/parse logic — 21 tests. Full harness suite is now 30.)

## Testing
- `mvn -pl ai-document-system-prompt-harness-eval test` → 30 tests, BUILD SUCCESS.
- Non-deployed, test-only module (Sonar-coverage-excluded); the extraction is behaviour-preserving.

## Notes
- Scope: harness module only. The unrelated repo-root `docs/priority-consumer-fairness-design.md` is intentionally excluded.

**Jira:** DD-42967
